### PR TITLE
Feat/add item life cycle

### DIFF
--- a/lib/0_data/repositories/collection_repository_mock.dart
+++ b/lib/0_data/repositories/collection_repository_mock.dart
@@ -75,6 +75,13 @@ class CollectionRepositoryMock implements CollectionRepository {
     }
   }
 
+  @override
+  Future<Either<Failure, Item>> addItem(Item item) {
+    _itemIds.add(item.id);
+    _itemCollection[item.id.value] = item;
+    return Future.value(Right(item));
+  }
+
   Item modelToItem({required ItemModel itemModel}) {
     return Item(
       id: ItemId.fromUniqueString(itemModel.id),

--- a/lib/1_domain/repositories/collection_repository.dart
+++ b/lib/1_domain/repositories/collection_repository.dart
@@ -9,4 +9,6 @@ abstract class CollectionRepository {
   Future<Either<Failure, List<Item>>> readItems();
 
   Future<Either<Failure, Item>> readItem(ItemId itemId);
+
+  Future<Either<Failure, Item>> addItem(Item item);
 }

--- a/lib/1_domain/use_cases/add_collection_item.dart
+++ b/lib/1_domain/use_cases/add_collection_item.dart
@@ -1,0 +1,21 @@
+import 'package:either_dart/either.dart';
+
+import 'use_case.dart';
+import '../failures/failures.dart';
+import '../repositories/collection_repository.dart';
+import '../entities/item.dart';
+
+class AddCollectionItem implements UseCase<Item, AddItemParams> {
+  final CollectionRepository collectionRepository;
+  const AddCollectionItem({required this.collectionRepository});
+
+  @override
+  Future<Either<Failure, Item>> call(AddItemParams params) async {
+    try {
+      final itemIds = await collectionRepository.addItem(params.item);
+      return itemIds.fold((left) => Left(left), (right) => Right(right));
+    } on Exception catch (e) {
+      return Left(ServerFailure(stackTrace: e.toString()));
+    }
+  }
+}

--- a/lib/1_domain/use_cases/use_case.dart
+++ b/lib/1_domain/use_cases/use_case.dart
@@ -1,7 +1,9 @@
 import 'package:either_dart/either.dart';
 import 'package:equatable/equatable.dart';
-import 'package:ludoteca/1_domain/entities/unique_id.dart';
-import 'package:ludoteca/1_domain/failures/failures.dart';
+
+import '../entities/unique_id.dart';
+import '../failures/failures.dart';
+import '../entities/item.dart';
 
 abstract class UseCase<Type, Params> {
   Future<Either<Failure, Type>> call(Params params);
@@ -21,4 +23,13 @@ class ItemParams extends Params {
 
   @override
   List<Object?> get props => [itemId];
+}
+
+class AddItemParams extends Params {
+  final Item item;
+
+  AddItemParams({required this.item});
+
+  @override
+  List<Object?> get props => [item];
 }

--- a/lib/2_application/pages/collection/collection_add_item/collection_add_item_page.dart
+++ b/lib/2_application/pages/collection/collection_add_item/collection_add_item_page.dart
@@ -1,15 +1,19 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_adaptive_scaffold/flutter_adaptive_scaffold.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
-import 'package:ludoteca/1_domain/entities/unique_id.dart';
-import 'package:ludoteca/1_domain/repositories/collection_repository.dart';
-import 'package:ludoteca/1_domain/use_cases/get_item.dart';
-import 'package:ludoteca/2_application/pages/collection/collection_add_item/cubit/collection_add_item_cubit.dart';
-import 'package:ludoteca/2_application/pages/collection/collection_add_item/view_states/collection_add_item_empty.dart';
-import 'package:ludoteca/2_application/pages/collection/collection_add_item/view_states/collection_add_item_error.dart';
-import 'package:ludoteca/2_application/pages/collection/collection_add_item/view_states/collection_add_item_loaded.dart';
-import 'package:ludoteca/2_application/pages/collection/collection_add_item/view_states/collection_add_item_loading.dart';
-import 'package:ludoteca/2_application/pages/collection/collection_page.dart';
+import 'package:ludoteca/2_application/pages/collection/cubit/collection_cubit.dart';
+import '../../../../1_domain/entities/unique_id.dart';
+import '../../../../1_domain/entities/item.dart';
+import '../../../../1_domain/repositories/collection_repository.dart';
+import '../../../../1_domain/use_cases/add_collection_item.dart';
+import '../../../../1_domain/use_cases/get_item.dart';
+import '../collection_page.dart';
+import 'cubit/collection_add_item_cubit.dart';
+import 'view_states/collection_add_item_empty.dart';
+import 'view_states/collection_add_item_error.dart';
+import 'view_states/collection_add_item_loaded.dart';
+import 'view_states/collection_add_item_loading.dart';
 
 class CollectionAddItemPageProvider extends StatelessWidget {
   final bool showAppBar;
@@ -21,10 +25,12 @@ class CollectionAddItemPageProvider extends StatelessWidget {
   Widget build(BuildContext context) {
     return BlocProvider(
       create: (context) {
+        final collectionRepository =
+            RepositoryProvider.of<CollectionRepository>(context);
         return CollectionAddItemCubit(
-          getItem: GetItem(
-            collectionRepository:
-                RepositoryProvider.of<CollectionRepository>(context),
+          getItem: GetItem(collectionRepository: collectionRepository),
+          addItem: AddCollectionItem(
+            collectionRepository: collectionRepository,
           ),
         );
       },
@@ -43,61 +49,88 @@ class CollectionAddItemPage extends StatelessWidget {
   Widget build(BuildContext context) {
     return BlocBuilder<CollectionAddItemCubit, CollectionAddItemCubitState>(
       builder: (context, state) {
-        return Scaffold(
-          backgroundColor: Colors.black54,
-          appBar: showAppBar
-              ? AppBar(
-                  title: Text(title ?? ''),
-                  leading: IconButton(
-                    icon: const Icon(Icons.arrow_back),
-                    onPressed: () {
-                      if (context.canPop()) {
-                        context.pop();
-                        return;
-                      }
-                      context.goNamed(
-                        'shell',
-                        pathParameters: {'tab': CollectionPage.pageConfig.name},
-                      );
-                    },
-                  ),
-                )
-              : null,
-          body: Builder(
-            builder: (context) {
-              Widget body;
-              if (state is CollectionAddItemLoadingState) {
-                body = const CollectionAddItemLoading();
-              } else if (state is CollectionAddItemErrorState) {
-                body = const CollectionAddItemError();
-              } else if (state is CollectionAddItemLoadedState) {
-                body = CollectionAddItemLoaded(
-                  key: Key(state.item.id.value),
-                  item: state.item,
-                );
-              } else {
-                body = const CollectionAddItemEmpty();
-              }
-              return SingleChildScrollView(
-                child: Column(
-                  children: [
-                    Padding(
-                      padding: const EdgeInsets.all(8.0),
-                      child: SearchBar(
-                        leading: const Icon(Icons.search_outlined),
-                        hintText: 'BGG id',
-                        onSubmitted: (value) {
-                          context
-                              .read<CollectionAddItemCubit>()
-                              .readItemDetail(ItemId.fromUniqueString(value));
-                        },
-                      ),
+        closePage({Item? item}) {
+          if (Breakpoints.small.isActive(context)) {
+            if (context.canPop()) {
+              context.pop(item);
+              return;
+            }
+            context.goNamed(
+              'shell',
+              pathParameters: {'tab': CollectionPage.pageConfig.name},
+            );
+            return;
+          }
+
+          if (item != null) {
+            context.read<CollectionCubit>().itemAdded(item);
+          }
+        }
+
+        return BlocListener<CollectionAddItemCubit,
+            CollectionAddItemCubitState>(
+          listener: (context, state) {
+            if (state is CollectionAddItemAddedState) {
+              closePage(item: state.item);
+            }
+          },
+          child: Scaffold(
+            backgroundColor: Colors.black54,
+            appBar: showAppBar
+                ? AppBar(
+                    title: Text(title ?? ''),
+                    leading: IconButton(
+                      icon: const Icon(Icons.arrow_back),
+                      onPressed: closePage,
                     ),
-                    body,
-                  ],
-                ),
-              );
-            },
+                  )
+                : null,
+            body: Builder(
+              builder: (context) {
+                Widget body;
+                if (state is CollectionAddItemLoadingState) {
+                  body = const CollectionAddItemLoading();
+                } else if (state is CollectionAddItemErrorState) {
+                  body = const CollectionAddItemError();
+                } else if (state is CollectionAddItemLoadedState) {
+                  body = CollectionAddItemLoaded(
+                    key: Key(state.item.id.value),
+                    item: state.item,
+                  );
+                } else {
+                  body = const CollectionAddItemEmpty();
+                }
+                return SingleChildScrollView(
+                  child: Column(
+                    children: [
+                      Padding(
+                        padding: const EdgeInsets.all(8.0),
+                        child: SearchBar(
+                          leading: const Icon(Icons.search_outlined),
+                          hintText: 'BGG id',
+                          onSubmitted: (value) {
+                            context
+                                .read<CollectionAddItemCubit>()
+                                .readItemDetail(ItemId.fromUniqueString(value));
+                          },
+                        ),
+                      ),
+                      body,
+                    ],
+                  ),
+                );
+              },
+            ),
+            floatingActionButton: FloatingActionButton(
+              child: const Icon(Icons.done_outline_outlined),
+              onPressed: () {
+                if (state is CollectionAddItemLoadedState) {
+                  context
+                      .read<CollectionAddItemCubit>()
+                      .addCollectionItem(state.item);
+                }
+              },
+            ),
           ),
         );
       },

--- a/lib/2_application/pages/collection/collection_add_item/cubit/collection_add_item_cubit.dart
+++ b/lib/2_application/pages/collection/collection_add_item/cubit/collection_add_item_cubit.dart
@@ -2,6 +2,7 @@ import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:ludoteca/1_domain/entities/item.dart';
 import 'package:ludoteca/1_domain/entities/unique_id.dart';
+import 'package:ludoteca/1_domain/use_cases/add_collection_item.dart';
 import 'package:ludoteca/1_domain/use_cases/get_item.dart';
 import 'package:ludoteca/1_domain/use_cases/use_case.dart';
 
@@ -9,10 +10,11 @@ part 'collection_add_item_cubit_state.dart';
 
 class CollectionAddItemCubit extends Cubit<CollectionAddItemCubitState> {
   final GetItem getItem;
-  CollectionAddItemCubit({required this.getItem})
+  final AddCollectionItem addItem;
+  CollectionAddItemCubit({required this.getItem, required this.addItem})
       : super(const CollectionAddItemEmptyState());
 
-  Future<void> readItemDetail(ItemId itemId) async {
+  void readItemDetail(ItemId itemId) async {
     emit(const CollectionAddItemLoadingState());
 
     final item = await getItem(ItemParams(itemId: itemId));
@@ -21,6 +23,18 @@ class CollectionAddItemCubit extends Cubit<CollectionAddItemCubitState> {
       emit(const CollectionAddItemErrorState());
     } else {
       emit(CollectionAddItemLoadedState(item: item.right));
+    }
+  }
+
+  void addCollectionItem(Item item) async {
+    emit(const CollectionAddItemLoadingState());
+
+    final addedItem = await addItem(AddItemParams(item: item));
+
+    if (addedItem.isLeft) {
+      emit(const CollectionAddItemErrorState());
+    } else {
+      emit(CollectionAddItemAddedState(item: item));
     }
   }
 }

--- a/lib/2_application/pages/collection/collection_add_item/cubit/collection_add_item_cubit_state.dart
+++ b/lib/2_application/pages/collection/collection_add_item/cubit/collection_add_item_cubit_state.dart
@@ -26,3 +26,11 @@ final class CollectionAddItemLoadedState extends CollectionAddItemCubitState {
 final class CollectionAddItemEmptyState extends CollectionAddItemCubitState {
   const CollectionAddItemEmptyState();
 }
+
+final class CollectionAddItemAddedState extends CollectionAddItemCubitState {
+  final Item item;
+  const CollectionAddItemAddedState({required this.item}) : super();
+
+  @override
+  List<Object> get props => [item];
+}

--- a/lib/2_application/pages/collection/collection_item_detail/cubit/collection_item_detail_cubit.dart
+++ b/lib/2_application/pages/collection/collection_item_detail/cubit/collection_item_detail_cubit.dart
@@ -12,7 +12,7 @@ class CollectionItemDetailCubit extends Cubit<CollectionItemDetailCubitState> {
   CollectionItemDetailCubit({required this.getItem})
       : super(const CollectionItemDetailEmptyState());
 
-  Future<void> readItemDetail(ItemId? itemId) async {
+  void readItemDetail(ItemId? itemId) async {
     if (itemId == null) {
       emit(const CollectionItemDetailEmptyState());
       return;

--- a/lib/2_application/pages/collection/collection_list/cubit/collection_list_cubit.dart
+++ b/lib/2_application/pages/collection/collection_list/cubit/collection_list_cubit.dart
@@ -14,7 +14,7 @@ class CollectionListCubit extends Cubit<CollectionListCubitState> {
     CollectionListCubitState? initialState,
   }) : super(initialState ?? const CollectionListLoadingState());
 
-  Future<void> readItems() async {
+  void readItems() async {
     final items = await getCollectionItems(NoParams());
 
     if (items.isLeft) {
@@ -22,5 +22,9 @@ class CollectionListCubit extends Cubit<CollectionListCubitState> {
     } else {
       emit(CollectionListItemsLoadedState(items: items.right));
     }
+  }
+
+  void updateCollection(List<Item> items) {
+    emit(CollectionListItemsLoadedState(items: items));
   }
 }

--- a/lib/2_application/pages/collection/collection_list/view_states/collection_list_loaded.dart
+++ b/lib/2_application/pages/collection/collection_list/view_states/collection_list_loaded.dart
@@ -1,9 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:ludoteca/1_domain/entities/item.dart';
-import 'package:ludoteca/1_domain/entities/unique_id.dart';
-import 'package:ludoteca/2_application/pages/collection/collection_list/widgets/collection_list_item.dart';
-import 'package:ludoteca/2_application/pages/collection/cubit/collection_cubit.dart';
+
+import '../../../../../1_domain/entities/item.dart';
+import '../../../../../1_domain/entities/unique_id.dart';
+import '../widgets/collection_list_item.dart';
+import '../../cubit/collection_cubit.dart';
+import '../cubit/collection_list_cubit.dart';
 
 class CollectionListLoaded extends StatelessWidget {
   final List<Item> items;
@@ -31,23 +33,32 @@ class CollectionListLoaded extends StatelessWidget {
       collectionCubit.setAddingItem();
     }
 
-    return Scaffold(
-      body: Center(
-        child: ListView.builder(
-          itemCount: items.length,
-          itemBuilder: (context, index) {
-            return CollectionListItem(
-              item: items[index],
-              selected: selectedItem == items[index].id,
-              onTap: () => onItemTap(index),
-            );
-          },
+    return BlocListener<CollectionCubit, CollectionCubitState>(
+      listener: (context, state) {
+        if (state is CollectionItemAddedState && !items.contains(state.item)) {
+          context
+              .read<CollectionListCubit>()
+              .updateCollection(List<Item>.from(items)..add(state.item));
+        }
+      },
+      child: Scaffold(
+        body: Center(
+          child: ListView.builder(
+            itemCount: items.length,
+            itemBuilder: (context, index) {
+              return CollectionListItem(
+                item: items[index],
+                selected: selectedItem == items[index].id,
+                onTap: () => onItemTap(index),
+              );
+            },
+          ),
         ),
-      ),
-      floatingActionButton: FloatingActionButton(
-        key: const Key('add_item_fab'),
-        onPressed: onAddItemTap,
-        child: const Icon(Icons.add),
+        floatingActionButton: FloatingActionButton(
+          key: const Key('add_item_fab'),
+          onPressed: onAddItemTap,
+          child: const Icon(Icons.add),
+        ),
       ),
     );
   }

--- a/lib/2_application/pages/collection/collection_page.dart
+++ b/lib/2_application/pages/collection/collection_page.dart
@@ -8,6 +8,7 @@ import 'package:ludoteca/2_application/pages/collection/collection_item_detail/c
 import 'package:ludoteca/2_application/pages/collection/collection_list/collection_list_page.dart';
 import 'package:ludoteca/2_application/pages/collection/cubit/collection_cubit.dart';
 
+import '../../../1_domain/entities/item.dart';
 import '../../../1_domain/entities/unique_id.dart';
 
 class CollectionPageProvider extends StatelessWidget {
@@ -61,13 +62,21 @@ class _CollectionPageState extends State<CollectionPage> {
   @override
   Widget build(BuildContext context) {
     return BlocConsumer<CollectionCubit, CollectionCubitState>(
-      listener: (context, state) {
+      listener: (context, state) async {
+        final collectionCubit = context.read<CollectionCubit>();
         if (state is CollectionItemAddingState) {
+          late Item? item;
           if (Breakpoints.small.isActive(context)) {
-            context.pushNamed('addItem');
+            item = await context.pushNamed('addItem');
+            if (item != null) {
+              collectionCubit.itemAdded(item);
+            }
           }
-
-          changeSelection();
+          return;
+        }
+        if (state is CollectionItemAddedState &&
+            Breakpoints.mediumAndUp.isActive(context)) {
+          onSelectionChanged(context, state.item.id);
         }
       },
       builder: (context, state) {

--- a/lib/2_application/pages/collection/cubit/collection_cubit.dart
+++ b/lib/2_application/pages/collection/cubit/collection_cubit.dart
@@ -1,19 +1,24 @@
 import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
+import '../../../../1_domain/entities/item.dart';
+
 part 'collection_cubit_state.dart';
 
 class CollectionCubit extends Cubit<CollectionCubitState> {
-  CollectionCubit()
-      : super(const CollectionShowingState());
+  CollectionCubit() : super(const CollectionShowingState());
 
   void setAddingItem() {
     emit(const CollectionItemAddingState());
   }
 
   void setShowingState() {
-    if(state is! CollectionShowingState) {
+    if (state is! CollectionShowingState) {
       emit(const CollectionShowingState());
     }
+  }
+
+  void itemAdded(Item item) {
+    emit(CollectionItemAddedState(item: item));
   }
 }

--- a/lib/2_application/pages/collection/cubit/collection_cubit_state.dart
+++ b/lib/2_application/pages/collection/cubit/collection_cubit_state.dart
@@ -14,3 +14,11 @@ final class CollectionShowingState extends CollectionCubitState {
 final class CollectionItemAddingState extends CollectionCubitState {
   const CollectionItemAddingState();
 }
+
+final class CollectionItemAddedState extends CollectionCubitState {
+  final Item item;
+  const CollectionItemAddedState({required this.item});
+
+  @override
+  List<Object?> get props => [item];
+}

--- a/test/1_domain/use_cases/add_collection_item_test.dart
+++ b/test/1_domain/use_cases/add_collection_item_test.dart
@@ -1,0 +1,79 @@
+import 'package:either_dart/either.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:ludoteca/1_domain/entities/item.dart';
+import 'package:ludoteca/1_domain/entities/unique_id.dart';
+import 'package:ludoteca/1_domain/failures/failures.dart';
+import 'package:ludoteca/1_domain/repositories/collection_repository.dart';
+import 'package:ludoteca/1_domain/use_cases/add_collection_item.dart';
+import 'package:ludoteca/1_domain/use_cases/use_case.dart';
+import 'package:mocktail/mocktail.dart';
+
+class CollectionRepositoryMock extends Mock implements CollectionRepository {}
+
+void main() {
+  final fakeItem = Item(
+    id: ItemId.fromUniqueString('0'),
+    title: 'title',
+    instances: const [],
+    bggId: '122',
+    imageUrl: '',
+    thumbnailUrl: '',
+    description: 'longDescription',
+    minPlayers: 1,
+    maxPlayers: 4,
+    playingTime: 130,
+    author: 'author',
+    publisher: 'publisher',
+    publishYear: 2000,
+    complexity: 3.2,
+    rating: 6.5,
+  );
+
+  group('AddCollectionItem use case', () {
+    group('should return Right', () {
+      test('with an Item', () async {
+        final mockCollectionRepository = CollectionRepositoryMock();
+        when(() => mockCollectionRepository.addItem(fakeItem)).thenAnswer(
+          (_) async => Right(fakeItem),
+        );
+
+        final addCollectionItemUseCase = AddCollectionItem(
+          collectionRepository: mockCollectionRepository,
+        );
+
+        final result = await addCollectionItemUseCase(
+          AddItemParams(item: fakeItem),
+        );
+
+        expect(result, Right<Failure, Item>(fakeItem));
+
+        verify(() => mockCollectionRepository.addItem(fakeItem)).called(1);
+      });
+    });
+
+    group('should return left', () {
+      test('with a ServerFailure if threw an exception', () async {
+        final mockCollectionRepository = CollectionRepositoryMock();
+        when(() => mockCollectionRepository.addItem(fakeItem)).thenThrow(
+          Exception('something went wrong'),
+        );
+
+        final addCollectionItemUseCase = AddCollectionItem(
+          collectionRepository: mockCollectionRepository,
+        );
+
+        final result = await addCollectionItemUseCase(
+          AddItemParams(item: fakeItem),
+        );
+
+        expect(result.isLeft, true);
+        expect(
+          result.left,
+          ServerFailure(stackTrace: 'Exception: something went wrong'),
+        );
+
+        verify(() => mockCollectionRepository.addItem(fakeItem)).called(1);
+      });
+    });
+  });
+}

--- a/test/2_application/pages/collection/collection_list/cubit/collection_list_cubit_test.dart
+++ b/test/2_application/pages/collection/collection_list/cubit/collection_list_cubit_test.dart
@@ -43,7 +43,7 @@ void main() {
       );
 
       blocTest(
-        'CollectionListLoadedState when readItemIds succeeds',
+        'CollectionListItemsLoadedState when readItemIds succeeds',
         setUp: () => when(() => mockGetCollectionItemsUseCase.call(NoParams()))
             .thenAnswer(
           (invocation) => Future.value(
@@ -73,5 +73,32 @@ void main() {
         ],
       );
     });
+
+    blocTest(
+      'CollectionListItemsLoadedState when collection is updated',
+      build: () => CollectionListCubit(
+        getCollectionItems: mockGetCollectionItemsUseCase,
+      ),
+      act: (cubit) => cubit.updateCollection(
+        [
+          Item(
+            id: ItemId.fromUniqueString('0'),
+            title: 'title',
+            instances: const [],
+          ),
+        ],
+      ),
+      expect: () => <CollectionListCubitState>[
+        CollectionListItemsLoadedState(
+          items: [
+            Item(
+              id: ItemId.fromUniqueString('0'),
+              title: 'title',
+              instances: const [],
+            ),
+          ],
+        ),
+      ],
+    );
   });
 }

--- a/test/2_application/pages/collection/collection_list/view_states/collection_list_loaded_test.dart
+++ b/test/2_application/pages/collection/collection_list/view_states/collection_list_loaded_test.dart
@@ -1,13 +1,18 @@
+import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:ludoteca/1_domain/entities/item.dart';
 import 'package:ludoteca/1_domain/entities/unique_id.dart';
+import 'package:ludoteca/1_domain/use_cases/get_collection_items.dart';
+import 'package:ludoteca/2_application/pages/collection/collection_list/cubit/collection_list_cubit.dart';
 import 'package:ludoteca/2_application/pages/collection/collection_list/view_states/collection_list_loaded.dart';
 import 'package:ludoteca/2_application/pages/collection/collection_list/widgets/collection_list_item.dart';
 import 'package:ludoteca/2_application/pages/collection/cubit/collection_cubit.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:mocktail_image_network/mocktail_image_network.dart';
+
+import '../../../../../1_domain/use_cases/add_collection_item_test.dart';
 
 abstract class CallbackFunction {
   void call(ItemId id);
@@ -15,15 +20,36 @@ abstract class CallbackFunction {
 
 class OnItemTappedMock extends Mock implements CallbackFunction {}
 
+class MockCollectionCubit extends MockCubit<CollectionCubitState>
+    implements CollectionCubit {}
+
+class MockCollectionListCubit extends MockCubit<CollectionListCubitState>
+    implements CollectionListCubit {}
+
 void main() {
   Widget widgetUnderTest({
     required List<Item> items,
     Function(ItemId)? onItemTapped,
     ItemId? selectedItem,
+    MockCollectionCubit? mockCollectionCubit,
+    MockCollectionListCubit? mockCollectionListCubit,
   }) {
     return MaterialApp(
-      home: BlocProvider(
-        create: (context) => CollectionCubit(),
+      home: MultiBlocProvider(
+        providers: [
+          BlocProvider(
+            create: (context) => mockCollectionCubit ?? CollectionCubit(),
+          ),
+          BlocProvider(
+            create: (context) =>
+                mockCollectionListCubit ??
+                CollectionListCubit(
+                  getCollectionItems: GetCollectionItems(
+                    collectionRepository: CollectionRepositoryMock(),
+                  ),
+                ),
+          ),
+        ],
         child: Material(
           child: CollectionListLoaded(
             items: items,
@@ -88,5 +114,48 @@ void main() {
             .called(1);
       },
     );
+
+    testWidgets(
+        'should add an item to the list when an item is added to the state',
+        (WidgetTester widgetTester) async {
+      final mockCollectionCubit = MockCollectionCubit();
+      final mockCollectionListCubit = MockCollectionListCubit();
+
+      whenListen(
+        mockCollectionCubit,
+        Stream.fromIterable([
+          const CollectionShowingState(),
+          const CollectionItemAddingState(),
+          CollectionItemAddedState(item: Item.empty()),
+        ]),
+        initialState: const CollectionShowingState(),
+      );
+
+      when(() => mockCollectionCubit.state).thenReturn(
+        CollectionItemAddedState(item: Item.empty()),
+      );
+
+      await mockNetworkImages(
+        () async => widgetTester.pumpWidget(
+          widgetUnderTest(
+            items: List<Item>.generate(
+              2,
+              (index) => Item(
+                id: ItemId.fromUniqueString('$index'),
+                title: '',
+                instances: const [],
+              ),
+              growable: false,
+            ),
+            mockCollectionCubit: mockCollectionCubit,
+            mockCollectionListCubit: mockCollectionListCubit,
+          ),
+        ),
+      );
+
+      await widgetTester.pumpAndSettle();
+
+      verify(() => mockCollectionListCubit.updateCollection(any())).called(1);
+    });
   });
 }

--- a/test/2_application/pages/collection/collection_page_test.dart
+++ b/test/2_application/pages/collection/collection_page_test.dart
@@ -19,8 +19,6 @@ import '../../../mocks/go_route_mock.dart';
 class MockCollectionCubit extends MockCubit<CollectionCubitState>
     implements CollectionCubit {}
 
-class MockBggDataSource extends Mock implements BggDataSource {}
-
 void main() {
   Widget widgetUnderTest({MockGoRouter? router}) {
     return MaterialApp(

--- a/test/2_application/pages/collection/cubit/collection_cubit_test.dart
+++ b/test/2_application/pages/collection/cubit/collection_cubit_test.dart
@@ -1,5 +1,7 @@
 import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:ludoteca/1_domain/entities/item.dart';
+import 'package:ludoteca/1_domain/entities/unique_id.dart';
 import 'package:ludoteca/2_application/pages/collection/cubit/collection_cubit.dart';
 
 void main() {
@@ -16,6 +18,22 @@ void main() {
         build: () => CollectionCubit(),
         act: (cubit) => cubit.setAddingItem(),
         expect: () => const <CollectionCubitState>[CollectionItemAddingState()],
+      );
+
+      blocTest(
+        '[CollectionItemAddedState] when item is added',
+        build: () => CollectionCubit(),
+        act: (cubit) => cubit.itemAdded(Item(
+            id: ItemId.fromUniqueString('1'), title: '', instances: const [])),
+        expect: () => <CollectionCubitState>[
+          CollectionItemAddedState(
+            item: Item(
+              id: ItemId.fromUniqueString('1'),
+              title: '',
+              instances: const [],
+            ),
+          )
+        ],
       );
     });
   });


### PR DESCRIPTION
This PR is a bit messy, but I finally could add items to the collection (from bgg data).
I had some trouble testing cubits, so I removed the `Future<void>` returning types (that don't add any value IMO)
The biggest issue here was to stablish a FSM for adding items, as I DON'T want to share the CollectionCubit over the router (so components navigated through router can access it, in small screens)
Probably there's a better way of handling this, but I jut ran out of ideas with it.

I expect next PRs to be far more small.