### PR TITLE
chore: extracts bgg source to its own repository

### DIFF
--- a/lib/0_data/repositories/bgg_repository.dart
+++ b/lib/0_data/repositories/bgg_repository.dart
@@ -1,0 +1,37 @@
+import 'package:either_dart/either.dart';
+import 'package:ludoteca/0_data/data_sources/bgg_data_source.dart';
+import 'package:ludoteca/0_data/models/item_model.dart';
+import 'package:ludoteca/1_domain/entities/item.dart';
+import 'package:ludoteca/1_domain/entities/unique_id.dart';
+import 'package:ludoteca/1_domain/failures/failures.dart';
+
+class BggRepository {
+  final BggDataSource _bggDataSource;
+
+  BggRepository({required BggDataSource bggDataSource})
+      : _bggDataSource = bggDataSource;
+
+  Future<Either<Failure, Item>> getItem(String itemId) async {
+    try {
+      final itemModel = await _bggDataSource.getItem(id: itemId);
+      Item item = modelToItem(itemModel);
+      return Future.value(Right(item));
+    } on Exception catch (e) {
+      return Future.value(Left(ServerFailure(stackTrace: e.toString())));
+    }
+  }
+
+  Item modelToItem(ItemModel itemModel) {
+    return Item(
+      id: ItemId.fromUniqueString(itemModel.id),
+      title: itemModel.title,
+      description: itemModel.description,
+      instances: const [],
+      imageUrl: itemModel.imageUrl,
+      minAge: itemModel.minAge,
+      minPlayers: itemModel.minPlayers,
+      maxPlayers: itemModel.maxPlayers,
+      playingTime: itemModel.playingTime,
+    );
+  }
+}

--- a/lib/0_data/repositories/collection_repository_mock.dart
+++ b/lib/0_data/repositories/collection_repository_mock.dart
@@ -1,7 +1,6 @@
 import 'dart:math';
 
 import 'package:either_dart/either.dart';
-import 'package:ludoteca/0_data/data_sources/bgg_data_source.dart';
 import 'package:ludoteca/0_data/models/item_model.dart';
 import 'package:ludoteca/1_domain/entities/item.dart';
 import 'package:ludoteca/1_domain/entities/unique_id.dart';
@@ -9,7 +8,6 @@ import 'package:ludoteca/1_domain/failures/failures.dart';
 import 'package:ludoteca/1_domain/repositories/collection_repository.dart';
 
 class CollectionRepositoryMock implements CollectionRepository {
-  final BggDataSource bggDataSource;
   final List<ItemId> _itemIds = List<ItemId>.generate(
     20,
     (index) => ItemId.fromUniqueString('item-$index'),
@@ -21,7 +19,7 @@ class CollectionRepositoryMock implements CollectionRepository {
 
   final times = [5, 15, 30, 45, 60, 120, 180];
 
-  CollectionRepositoryMock({required this.bggDataSource}) {
+  CollectionRepositoryMock() {
     _itemCollection = Map.fromEntries(
       _itemIds.map(
         (item) {
@@ -63,16 +61,9 @@ class CollectionRepositoryMock implements CollectionRepository {
   Future<Either<Failure, Item>> readItem(ItemId itemId) async {
     Item? item = _itemCollection[itemId.value];
     if (item == null) {
-      try {
-        final itemModel = await bggDataSource.getItem(id: itemId.value);
-        Item item = modelToItem(itemModel: itemModel);
-        return Future.value(Right(item));
-      } on Exception catch (e) {
-        return Future.value(Left(ServerFailure(stackTrace: e.toString())));
-      }
-    } else {
-      return Future.value(Right(item));
+      return Future.value(Left(ServerFailure(stackTrace: e.toString())));
     }
+    return Future.value(Right(item));
   }
 
   @override

--- a/lib/1_domain/use_cases/get_bgg_item.dart
+++ b/lib/1_domain/use_cases/get_bgg_item.dart
@@ -1,0 +1,21 @@
+import 'package:either_dart/either.dart';
+import 'package:ludoteca/0_data/repositories/bgg_repository.dart';
+import 'package:ludoteca/1_domain/entities/item.dart';
+import 'package:ludoteca/1_domain/failures/failures.dart';
+import 'package:ludoteca/1_domain/use_cases/use_case.dart';
+
+class GetBggItem implements UseCase<Item, GetBggItemParams> {
+  final BggRepository bggRepository;
+
+  const GetBggItem({required this.bggRepository});
+
+  @override
+  Future<Either<Failure, Item>> call(GetBggItemParams params) async {
+    try {
+      final item = await bggRepository.getItem(params.itemId);
+      return item.fold((left) => Left(left), (right) => Right(right));
+    } on Exception catch (e) {
+      return Left(ServerFailure(stackTrace: e.toString()));
+    }
+  }
+}

--- a/lib/1_domain/use_cases/use_case.dart
+++ b/lib/1_domain/use_cases/use_case.dart
@@ -33,3 +33,12 @@ class AddItemParams extends Params {
   @override
   List<Object?> get props => [item];
 }
+
+class GetBggItemParams extends Params {
+  final String itemId;
+
+  GetBggItemParams({required this.itemId});
+
+  @override
+  List<Object?> get props => [itemId];
+}

--- a/lib/2_application/app.dart
+++ b/lib/2_application/app.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:ludoteca/0_data/data_sources/bgg_data_source.dart';
+import 'package:ludoteca/0_data/repositories/bgg_repository.dart';
 import 'package:ludoteca/0_data/repositories/collection_repository_mock.dart';
 import 'package:ludoteca/1_domain/repositories/collection_repository.dart';
 import 'package:ludoteca/2_application/core/routes.dart';
@@ -12,10 +13,15 @@ class App extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return RepositoryProvider<CollectionRepository>(
-      create: (context) => CollectionRepositoryMock(
-        bggDataSource: BggDataSource(),
-      ),
+    return MultiRepositoryProvider(
+      providers: [
+        RepositoryProvider<BggRepository>(
+          create: (context) => BggRepository(bggDataSource: BggDataSource()),
+        ),
+        RepositoryProvider<CollectionRepository>(
+          create: (context) => CollectionRepositoryMock(),
+        ),
+      ],
       child: MaterialApp.router(
         title: 'Ludoteca app',
         routerConfig: routes,

--- a/lib/2_application/pages/collection/collection_add_item/collection_add_item_page.dart
+++ b/lib/2_application/pages/collection/collection_add_item/collection_add_item_page.dart
@@ -2,12 +2,12 @@ import 'package:flutter/material.dart';
 import 'package:flutter_adaptive_scaffold/flutter_adaptive_scaffold.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
+import 'package:ludoteca/0_data/repositories/bgg_repository.dart';
+import 'package:ludoteca/1_domain/use_cases/get_bgg_item.dart';
 import 'package:ludoteca/i18n/strings.g.dart';
-import '../../../../1_domain/entities/unique_id.dart';
 import '../../../../1_domain/entities/item.dart';
 import '../../../../1_domain/repositories/collection_repository.dart';
 import '../../../../1_domain/use_cases/add_collection_item.dart';
-import '../../../../1_domain/use_cases/get_item.dart';
 import '../collection_page.dart';
 import 'cubit/collection_add_item_cubit.dart';
 import 'view_states/collection_add_item_empty.dart';
@@ -32,8 +32,9 @@ class CollectionAddItemPageProvider extends StatelessWidget {
       create: (context) {
         final collectionRepository =
             RepositoryProvider.of<CollectionRepository>(context);
+        final bggRepository = RepositoryProvider.of<BggRepository>(context);
         return CollectionAddItemCubit(
-          getItem: GetItem(collectionRepository: collectionRepository),
+          getBggItem: GetBggItem(bggRepository: bggRepository),
           addItem: AddCollectionItem(
             collectionRepository: collectionRepository,
           ),
@@ -127,8 +128,7 @@ class CollectionAddItemPage extends StatelessWidget {
                             onSubmitted: (value) {
                               context
                                   .read<CollectionAddItemCubit>()
-                                  .readItemDetail(
-                                      ItemId.fromUniqueString(value));
+                                  .readItemDetail(value);
                             },
                           ),
                         ),

--- a/lib/2_application/pages/collection/collection_add_item/cubit/collection_add_item_cubit.dart
+++ b/lib/2_application/pages/collection/collection_add_item/cubit/collection_add_item_cubit.dart
@@ -1,23 +1,22 @@
 import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:ludoteca/1_domain/entities/item.dart';
-import 'package:ludoteca/1_domain/entities/unique_id.dart';
 import 'package:ludoteca/1_domain/use_cases/add_collection_item.dart';
-import 'package:ludoteca/1_domain/use_cases/get_item.dart';
+import 'package:ludoteca/1_domain/use_cases/get_bgg_item.dart';
 import 'package:ludoteca/1_domain/use_cases/use_case.dart';
 
 part 'collection_add_item_cubit_state.dart';
 
 class CollectionAddItemCubit extends Cubit<CollectionAddItemCubitState> {
-  final GetItem getItem;
+  final GetBggItem getBggItem;
   final AddCollectionItem addItem;
-  CollectionAddItemCubit({required this.getItem, required this.addItem})
+  CollectionAddItemCubit({required this.getBggItem, required this.addItem})
       : super(const CollectionAddItemEmptyState());
 
-  void readItemDetail(ItemId itemId) async {
+  void readItemDetail(String itemId) async {
     emit(const CollectionAddItemLoadingState());
 
-    final item = await getItem(ItemParams(itemId: itemId));
+    final item = await getBggItem(GetBggItemParams(itemId: itemId));
 
     if (item.isLeft) {
       emit(const CollectionAddItemErrorState());

--- a/test/0_data/repositories/bgg_repository_test.dart
+++ b/test/0_data/repositories/bgg_repository_test.dart
@@ -1,0 +1,87 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:ludoteca/0_data/models/item_model.dart';
+import 'package:ludoteca/0_data/repositories/bgg_repository.dart';
+import 'package:ludoteca/0_data/data_sources/bgg_data_source.dart';
+import 'package:ludoteca/1_domain/entities/item.dart';
+import 'package:ludoteca/1_domain/entities/unique_id.dart';
+import 'package:ludoteca/1_domain/failures/failures.dart';
+import 'package:either_dart/either.dart';
+import 'package:mocktail/mocktail.dart';
+
+class MockBggDataSource extends Mock implements BggDataSource {}
+
+void main() {
+  group('BggRepository', () {
+    late BggRepository bggRepository;
+    late MockBggDataSource mockBggDataSource;
+
+    setUp(() {
+      mockBggDataSource = MockBggDataSource();
+      bggRepository = BggRepository(bggDataSource: mockBggDataSource);
+    });
+
+    test('getItem should return Right with valid item', () async {
+      // Arrange
+      const itemModel = ItemModel(
+        id: '123',
+        title: 'title',
+        imageUrl: 'imageUrl',
+        description: 'description',
+        minAge: 1,
+        minPlayers: 1,
+        maxPlayers: 1,
+        playingTime: 1,
+      );
+
+      when(() => mockBggDataSource.getItem(id: itemModel.id))
+          .thenAnswer((_) => Future.value(itemModel));
+
+      final result = await bggRepository.getItem(itemModel.id);
+
+      expect(result, equals(Right(bggRepository.modelToItem(itemModel))));
+    });
+
+    test('getItem should return Left with ServerFailure on exception',
+        () async {
+      when(() => mockBggDataSource.getItem(id: '123'))
+          .thenThrow(Exception('whatever'));
+
+      final result = await bggRepository.getItem('123');
+
+      expect(result.isLeft, true);
+      expect(result.left, isA<ServerFailure>());
+    });
+
+    test('modelToItem should return Item', () {
+      // Arrange
+      const itemModel = ItemModel(
+        id: '123',
+        title: 'title',
+        imageUrl: 'imageUrl',
+        description: 'description',
+        minAge: 1,
+        minPlayers: 1,
+        maxPlayers: 1,
+        playingTime: 1,
+      );
+
+      // Act
+      final result = bggRepository.modelToItem(itemModel);
+
+      // Assert
+      expect(
+          result,
+          equals(Item(
+            id: ItemId.fromUniqueString(itemModel.id),
+            title: itemModel.title,
+            imageUrl: itemModel.imageUrl,
+            description: itemModel.description,
+            minAge: itemModel.minAge,
+            minPlayers: itemModel.minPlayers,
+            maxPlayers: itemModel.maxPlayers,
+            playingTime: itemModel.playingTime,
+            instances: const [],
+          )));
+    });
+  });
+}

--- a/test/1_domain/use_cases/get_bgg_item_test.dart
+++ b/test/1_domain/use_cases/get_bgg_item_test.dart
@@ -1,0 +1,76 @@
+import 'package:either_dart/either.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:ludoteca/0_data/repositories/bgg_repository.dart';
+import 'package:ludoteca/1_domain/entities/item.dart';
+import 'package:ludoteca/1_domain/entities/unique_id.dart';
+import 'package:ludoteca/1_domain/failures/failures.dart';
+import 'package:ludoteca/1_domain/use_cases/get_bgg_item.dart';
+import 'package:ludoteca/1_domain/use_cases/use_case.dart';
+import 'package:mocktail/mocktail.dart';
+
+class BggRepositoryMock extends Mock implements BggRepository {}
+
+void main() {
+  final fakeItem = Item(
+    id: ItemId.fromUniqueString('0'),
+    title: 'title',
+    instances: const [],
+    bggId: '122',
+    imageUrl: '',
+    thumbnailUrl: '',
+    description: 'longDescription',
+    minPlayers: 1,
+    maxPlayers: 4,
+    playingTime: 130,
+    author: 'author',
+    publisher: 'publisher',
+    publishYear: 2000,
+    complexity: 3.2,
+    rating: 6.5,
+  );
+
+  group('GetBggItemDetail use case', () {
+    group('should return Right', () {
+      test('with an ItemDetail', () async {
+        final mockBggRepository = BggRepositoryMock();
+        when(() => mockBggRepository.getItem('0')).thenAnswer(
+          (_) async => Right(fakeItem),
+        );
+
+        final getItemDetailUseCase = GetBggItem(
+          bggRepository: mockBggRepository,
+        );
+
+        final result =
+            await getItemDetailUseCase(GetBggItemParams(itemId: '0'));
+
+        expect(result, Right<Failure, Item>(fakeItem));
+
+        verify(() => mockBggRepository.getItem('0')).called(1);
+      });
+    });
+
+    group('should return left', () {
+      test('with a ServerFailure if threw an exception', () async {
+        final mockBggRepository = BggRepositoryMock();
+        when(() => mockBggRepository.getItem('0')).thenThrow(
+          Exception('something went wrong'),
+        );
+
+        final getItemDetailUseCase =
+            GetBggItem(bggRepository: mockBggRepository);
+
+        final result =
+            await getItemDetailUseCase(GetBggItemParams(itemId: '0'));
+
+        expect(result.isLeft, true);
+        expect(
+          result.left,
+          ServerFailure(stackTrace: 'Exception: something went wrong'),
+        );
+
+        verify(() => mockBggRepository.getItem('0')).called(1);
+      });
+    });
+  });
+}

--- a/test/1_domain/use_cases/get_item_test.dart
+++ b/test/1_domain/use_cases/get_item_test.dart
@@ -29,7 +29,7 @@ void main() {
     rating: 6.5,
   );
 
-  group('GetItemDetail use case', () {
+  group('GetItem use case', () {
     group('should return Right', () {
       test('with an ItemDetail', () async {
         final mockCollectionRepository = CollectionRepositoryMock();

--- a/test/2_application/pages/collection/collection_add_item/collection_add_item_page_test.dart
+++ b/test/2_application/pages/collection/collection_add_item/collection_add_item_page_test.dart
@@ -196,10 +196,7 @@ void main() {
       await tester.testTextInput.receiveAction(TextInputAction.done);
       await tester.pump();
 
-      verify(
-        () => mockCollectionAddItemCubit
-            .readItemDetail(ItemId.fromUniqueString('111')),
-      ).called(1);
+      verify(() => mockCollectionAddItemCubit.readItemDetail('111')).called(1);
 
       final addButton = find.byIcon(Icons.done_outline_outlined);
       expect(addButton, findsOneWidget);

--- a/test/2_application/pages/collection/collection_add_item/cubit/collection_add_item_cubit_test.dart
+++ b/test/2_application/pages/collection/collection_add_item/cubit/collection_add_item_cubit_test.dart
@@ -4,19 +4,19 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:ludoteca/1_domain/entities/item.dart';
 import 'package:ludoteca/1_domain/entities/unique_id.dart';
 import 'package:ludoteca/1_domain/failures/failures.dart';
-import 'package:ludoteca/1_domain/use_cases/get_item.dart';
+import 'package:ludoteca/1_domain/use_cases/get_bgg_item.dart';
 import 'package:ludoteca/1_domain/use_cases/add_collection_item.dart';
 import 'package:ludoteca/1_domain/use_cases/use_case.dart';
 import 'package:ludoteca/2_application/pages/collection/collection_add_item/cubit/collection_add_item_cubit.dart';
 import 'package:mocktail/mocktail.dart';
 
-class MockGetItemDetailUseCase extends Mock implements GetItem {}
+class MockGetBggItemDetailUseCase extends Mock implements GetBggItem {}
 
 class MockAddCollectionItemUseCase extends Mock implements AddCollectionItem {}
 
 void main() {
   group('CollectionAddItemCubit', () {
-    final mockGetItemDetailUseCase = MockGetItemDetailUseCase();
+    final mockGetBggItemDetailUseCase = MockGetBggItemDetailUseCase();
     final mockAddCollectionItemUseCase = MockAddCollectionItemUseCase();
 
     final fakeItem = Item(
@@ -41,7 +41,7 @@ void main() {
       blocTest(
         'nothing when no method is called',
         build: () => CollectionAddItemCubit(
-          getItem: mockGetItemDetailUseCase,
+          getBggItem: mockGetBggItemDetailUseCase,
           addItem: mockAddCollectionItemUseCase,
         ),
         expect: () => const <CollectionAddItemCubitState>[],
@@ -50,17 +50,17 @@ void main() {
       blocTest(
         'CollectionAddItemErrorState when readItemIds fails',
         setUp: () => when(
-          () => mockGetItemDetailUseCase.call(
-            ItemParams(
-              itemId: ItemId.fromUniqueString('itemId'),
+          () => mockGetBggItemDetailUseCase.call(
+            GetBggItemParams(
+              itemId: 'itemId',
             ),
           ),
         ).thenAnswer((invocation) => Future.value(Left(ServerFailure()))),
         build: () => CollectionAddItemCubit(
-          getItem: mockGetItemDetailUseCase,
+          getBggItem: mockGetBggItemDetailUseCase,
           addItem: mockAddCollectionItemUseCase,
         ),
-        act: (cubit) => cubit.readItemDetail(ItemId.fromUniqueString('itemId')),
+        act: (cubit) => cubit.readItemDetail('itemId'),
         expect: () => const <CollectionAddItemCubitState>[
           CollectionAddItemLoadingState(),
           CollectionAddItemErrorState(),
@@ -70,17 +70,14 @@ void main() {
       blocTest(
         'CollectionAddItemLoadedState when readItemDetail succeds',
         setUp: () => when(
-          () => mockGetItemDetailUseCase.call(
-            ItemParams(
-              itemId: ItemId.fromUniqueString('itemId'),
-            ),
-          ),
+          () => mockGetBggItemDetailUseCase
+              .call(GetBggItemParams(itemId: 'itemId'))
         ).thenAnswer((invocation) => Future.value(Right(fakeItem))),
         build: () => CollectionAddItemCubit(
-          getItem: mockGetItemDetailUseCase,
+          getBggItem: mockGetBggItemDetailUseCase,
           addItem: mockAddCollectionItemUseCase,
         ),
-        act: (cubit) => cubit.readItemDetail(ItemId.fromUniqueString('itemId')),
+        act: (cubit) => cubit.readItemDetail('itemId'),
         expect: () => <CollectionAddItemCubitState>[
           const CollectionAddItemLoadingState(),
           CollectionAddItemLoadedState(item: fakeItem),
@@ -95,7 +92,7 @@ void main() {
           ),
         ).thenAnswer((invocation) => Future.value(Left(ServerFailure()))),
         build: () => CollectionAddItemCubit(
-          getItem: mockGetItemDetailUseCase,
+          getBggItem: mockGetBggItemDetailUseCase,
           addItem: mockAddCollectionItemUseCase,
         ),
         act: (cubit) => cubit.addCollectionItem(fakeItem),
@@ -115,7 +112,7 @@ void main() {
           ),
         ).thenAnswer((invocation) => Future.value(Right(fakeItem))),
         build: () => CollectionAddItemCubit(
-          getItem: mockGetItemDetailUseCase,
+          getBggItem: mockGetBggItemDetailUseCase,
           addItem: mockAddCollectionItemUseCase,
         ),
         act: (cubit) => cubit.addCollectionItem(fakeItem),

--- a/test/2_application/pages/collection/collection_page_test.dart
+++ b/test/2_application/pages/collection/collection_page_test.dart
@@ -2,7 +2,7 @@ import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:ludoteca/0_data/data_sources/bgg_data_source.dart';
+import 'package:ludoteca/0_data/repositories/bgg_repository.dart';
 import 'package:ludoteca/0_data/repositories/collection_repository_mock.dart';
 import 'package:ludoteca/1_domain/repositories/collection_repository.dart';
 import 'package:ludoteca/2_application/pages/collection/collection_add_item/collection_add_item_page.dart';
@@ -20,20 +20,27 @@ import '../../../mocks/go_route_mock.dart';
 class MockCollectionCubit extends MockCubit<CollectionCubitState>
     implements CollectionCubit {}
 
+class MockBggRepository extends Mock implements BggRepository {}
+
 void main() {
   Widget widgetUnderTest({MockGoRouter? router}) {
     return withMaterialAppTranslation(
       Material(
         child: MockGoRouterProvider(
           goRouter: router ?? MockGoRouter(),
-          child: RepositoryProvider<CollectionRepository>(
-            create: (context) =>
-                CollectionRepositoryMock(bggDataSource: BggDataSource()),
-            child: BlocProvider(
-              create: (context) => CollectionCubit(),
-              child: const CollectionPage(),
-            ),
-          ),
+          child: MultiRepositoryProvider(
+              providers: [
+                RepositoryProvider<CollectionRepository>(
+                  create: (context) => CollectionRepositoryMock(),
+                ),
+                RepositoryProvider<BggRepository>(
+                  create: (context) => MockBggRepository(),
+                ),
+              ],
+              child: BlocProvider(
+                create: (context) => CollectionCubit(),
+                child: const CollectionPage(),
+              )),
         ),
       ),
     );


### PR DESCRIPTION
It does not have any sense to access to different API and data sources through the same repo. This way when we create new datasources we do not have to replicate this