### PR TITLE
Feat/item instances

### DIFF
--- a/lib/0_data/data_sources/hive_local_data_source.dart
+++ b/lib/0_data/data_sources/hive_local_data_source.dart
@@ -73,4 +73,10 @@ class HiveLocalDataSource implements CollectionLocalSourceInterface {
       return ItemInstanceModel.fromJson(itemInstance.cast<String, dynamic>());
     }).toList());
   }
+  
+  @override
+  Future<bool> addItemInstance({required ItemInstanceModel itemInstanceModel}) {
+    // TODO: implement addItemInstance
+    throw UnimplementedError();
+  }
 }

--- a/lib/0_data/data_sources/interfaces/collection_local_source_interface.dart
+++ b/lib/0_data/data_sources/interfaces/collection_local_source_interface.dart
@@ -1,3 +1,4 @@
+import 'package:ludoteca/0_data/models/item_instance_model.dart';
 import 'package:ludoteca/0_data/models/item_model.dart';
 
 abstract class CollectionLocalSourceInterface {
@@ -8,4 +9,6 @@ abstract class CollectionLocalSourceInterface {
   Future<ItemModel> readItem({required String itemId});
 
   Future<bool> addItem({required ItemModel itemModel});
+
+  Future<List<ItemInstanceModel>> readItemInstances(List<String> itemIds);
 }

--- a/lib/0_data/data_sources/interfaces/collection_local_source_interface.dart
+++ b/lib/0_data/data_sources/interfaces/collection_local_source_interface.dart
@@ -11,4 +11,6 @@ abstract class CollectionLocalSourceInterface {
   Future<bool> addItem({required ItemModel itemModel});
 
   Future<List<ItemInstanceModel>> readItemInstances(List<String> itemIds);
+
+  Future<bool> addItemInstance({required ItemInstanceModel itemInstanceModel});
 }

--- a/lib/0_data/exceptions/exceptions.dart
+++ b/lib/0_data/exceptions/exceptions.dart
@@ -14,6 +14,15 @@ class ItemNotFoundException implements Exception {
   }
 }
 
+class ItemInstanceNotFoundException implements Exception {
+  final String instanceId;
+  ItemInstanceNotFoundException(this.instanceId);
+
+  String get message {
+    return 'Item instance $instanceId not found';
+  }
+}
+
 class ItemParseFailedException implements Exception {
   final String data;
   final String itemId;

--- a/lib/0_data/models/item_instance_model.dart
+++ b/lib/0_data/models/item_instance_model.dart
@@ -1,0 +1,53 @@
+import 'package:equatable/equatable.dart';
+import 'package:json_annotation/json_annotation.dart';
+import 'package:ludoteca/1_domain/entities/item_instance.dart';
+
+part 'item_instance_model.g.dart';
+
+@JsonSerializable()
+class ItemInstanceModel extends Equatable {
+  final int instanceId;
+  final String itemId;
+  final String status;
+  final List<String>? incidences;
+  final DateTime? borrowedAt;
+  final DateTime? returnedAt;
+  final String? borrowedBy;
+
+  const ItemInstanceModel({
+    required this.instanceId,
+    required this.itemId,
+    required this.status,
+    this.incidences = const [],
+    this.borrowedAt,
+    this.returnedAt,
+    this.borrowedBy,
+  });
+
+  factory ItemInstanceModel.fromJson(Map<String, dynamic> json) =>
+      _$ItemInstanceModelFromJson(json);
+
+  factory ItemInstanceModel.fromItemInstance(ItemInstance itemInstance) =>
+      ItemInstanceModel(
+        instanceId: itemInstance.instanceId,
+        itemId: itemInstance.itemId.value,
+        status: itemInstance.status.name,
+        incidences: itemInstance.incidences,
+        borrowedAt: itemInstance.borrowedAt,
+        returnedAt: itemInstance.returnedAt,
+        borrowedBy: itemInstance.borrowedBy?.value,
+      );
+
+  Map<String, dynamic> toJson() => _$ItemInstanceModelToJson(this);
+
+  @override
+  List<Object?> get props => [
+        instanceId,
+        itemId,
+        status,
+        incidences,
+        borrowedAt,
+        returnedAt,
+        borrowedBy,
+      ];
+}

--- a/lib/0_data/models/item_instance_model.dart
+++ b/lib/0_data/models/item_instance_model.dart
@@ -6,7 +6,7 @@ part 'item_instance_model.g.dart';
 
 @JsonSerializable()
 class ItemInstanceModel extends Equatable {
-  final int instanceId;
+  final String id;
   final String itemId;
   final String status;
   final List<String>? incidences;
@@ -15,7 +15,7 @@ class ItemInstanceModel extends Equatable {
   final String? borrowedBy;
 
   const ItemInstanceModel({
-    required this.instanceId,
+    required this.id,
     required this.itemId,
     required this.status,
     this.incidences = const [],
@@ -29,7 +29,7 @@ class ItemInstanceModel extends Equatable {
 
   factory ItemInstanceModel.fromItemInstance(ItemInstance itemInstance) =>
       ItemInstanceModel(
-        instanceId: itemInstance.instanceId,
+        id: itemInstance.id.value,
         itemId: itemInstance.itemId.value,
         status: itemInstance.status.name,
         incidences: itemInstance.incidences,
@@ -42,7 +42,7 @@ class ItemInstanceModel extends Equatable {
 
   @override
   List<Object?> get props => [
-        instanceId,
+        id,
         itemId,
         status,
         incidences,

--- a/lib/0_data/models/item_instance_model.g.dart
+++ b/lib/0_data/models/item_instance_model.g.dart
@@ -8,7 +8,7 @@ part of 'item_instance_model.dart';
 
 ItemInstanceModel _$ItemInstanceModelFromJson(Map<String, dynamic> json) =>
     ItemInstanceModel(
-      instanceId: (json['instanceId'] as num).toInt(),
+      id: json['id'] as String,
       itemId: json['itemId'] as String,
       status: json['status'] as String,
       incidences: (json['incidences'] as List<dynamic>?)
@@ -26,7 +26,7 @@ ItemInstanceModel _$ItemInstanceModelFromJson(Map<String, dynamic> json) =>
 
 Map<String, dynamic> _$ItemInstanceModelToJson(ItemInstanceModel instance) =>
     <String, dynamic>{
-      'instanceId': instance.instanceId,
+      'id': instance.id,
       'itemId': instance.itemId,
       'status': instance.status,
       'incidences': instance.incidences,

--- a/lib/0_data/models/item_instance_model.g.dart
+++ b/lib/0_data/models/item_instance_model.g.dart
@@ -1,0 +1,36 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'item_instance_model.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+ItemInstanceModel _$ItemInstanceModelFromJson(Map<String, dynamic> json) =>
+    ItemInstanceModel(
+      instanceId: (json['instanceId'] as num).toInt(),
+      itemId: json['itemId'] as String,
+      status: json['status'] as String,
+      incidences: (json['incidences'] as List<dynamic>?)
+              ?.map((e) => e as String)
+              .toList() ??
+          const [],
+      borrowedAt: json['borrowedAt'] == null
+          ? null
+          : DateTime.parse(json['borrowedAt'] as String),
+      returnedAt: json['returnedAt'] == null
+          ? null
+          : DateTime.parse(json['returnedAt'] as String),
+      borrowedBy: json['borrowedBy'] as String?,
+    );
+
+Map<String, dynamic> _$ItemInstanceModelToJson(ItemInstanceModel instance) =>
+    <String, dynamic>{
+      'instanceId': instance.instanceId,
+      'itemId': instance.itemId,
+      'status': instance.status,
+      'incidences': instance.incidences,
+      'borrowedAt': instance.borrowedAt?.toIso8601String(),
+      'returnedAt': instance.returnedAt?.toIso8601String(),
+      'borrowedBy': instance.borrowedBy,
+    };

--- a/lib/0_data/models/item_model.dart
+++ b/lib/0_data/models/item_model.dart
@@ -66,7 +66,7 @@ class ItemModel extends Equatable {
         publishYear: item.publishYear,
         complexity: item.complexity,
         rating: item.rating,
-        instances: item.instances,
+        instances: item.instances.map((instaceId) => instaceId.value).toList(),
       );
 
   Map<String, dynamic> toJson() => _$ItemModelToJson(this);

--- a/lib/0_data/repositories/collection_repository_local.dart
+++ b/lib/0_data/repositories/collection_repository_local.dart
@@ -74,7 +74,7 @@ class CollectionRepositoryLocal implements CollectionRepository {
   }
 
   @override
-  Future<Either<Failure, List<ItemInstance>>> getItemInstances(
+  Future<Either<Failure, List<ItemInstance>>> readItemInstances(
       List<ItemInstanceId> itemIds) async {
     try {
       final instances = await localDataSource.readItemInstances(

--- a/lib/0_data/repositories/collection_repository_local.dart
+++ b/lib/0_data/repositories/collection_repository_local.dart
@@ -1,6 +1,7 @@
 import 'package:either_dart/either.dart';
 import 'package:ludoteca/0_data/data_sources/interfaces/collection_local_source_interface.dart';
 import 'package:ludoteca/0_data/exceptions/exceptions.dart';
+import 'package:ludoteca/0_data/models/item_instance_model.dart';
 import 'package:ludoteca/0_data/models/item_model.dart';
 import 'package:ludoteca/1_domain/entities/item.dart';
 import 'package:ludoteca/1_domain/entities/item_instance.dart';
@@ -83,6 +84,23 @@ class CollectionRepositoryLocal implements CollectionRepository {
           .toList());
     } on ItemInstanceNotFoundException catch (e) {
       return Left(ItemInstanceNotFoundFailure(itemInstanceId: e.instanceId));
+    } on CacheException catch (e) {
+      return Left(CacheFailure(stackTrace: e.toString()));
+    } on Exception catch (e) {
+      return Left(ServerFailure(stackTrace: e.toString()));
+    }
+  }
+
+  @override
+  Future<Either<Failure, ItemInstance>> addItemInstance(
+      ItemInstance itemInstance) async {
+    try {
+      final result = await localDataSource.addItemInstance(
+          itemInstanceModel: ItemInstanceModel.fromItemInstance(itemInstance));
+      if (!result) {
+        return Left(ItemNotFoundFailure(itemId: itemInstance.itemId.value));
+      }
+      return Right(itemInstance);
     } on CacheException catch (e) {
       return Left(CacheFailure(stackTrace: e.toString()));
     } on Exception catch (e) {

--- a/lib/0_data/repositories/collection_repository_mock.dart
+++ b/lib/0_data/repositories/collection_repository_mock.dart
@@ -130,6 +130,11 @@ class CollectionRepositoryMock implements CollectionRepository {
   @override
   Future<Either<Failure, ItemInstance>> addItemInstance(
       ItemInstance itemInstance) {
+    if (!_itemCollection.containsKey(itemInstance.itemId.value)) {
+      return Future.value(
+          Left(ItemNotFoundFailure(itemId: itemInstance.itemId.value)));
+    }
+    
     _itemCollection[itemInstance.itemId.value]!.instances.add(itemInstance.id);
     _itemInstances[itemInstance.id.value] = itemInstance;
     return Future.value(Right(itemInstance));

--- a/lib/0_data/repositories/collection_repository_mock.dart
+++ b/lib/0_data/repositories/collection_repository_mock.dart
@@ -2,7 +2,6 @@ import 'dart:math';
 
 import 'package:either_dart/either.dart';
 import 'package:ludoteca/0_data/exceptions/exceptions.dart';
-import 'package:ludoteca/0_data/models/item_model.dart';
 import 'package:ludoteca/1_domain/entities/item.dart';
 import 'package:ludoteca/1_domain/entities/item_instance.dart';
 import 'package:ludoteca/1_domain/entities/unique_id.dart';
@@ -134,20 +133,5 @@ class CollectionRepositoryMock implements CollectionRepository {
     _itemCollection[itemInstance.itemId.value]!.instances.add(itemInstance.id);
     _itemInstances[itemInstance.id.value] = itemInstance;
     return Future.value(Right(itemInstance));
-  }
-
-  Item modelToItem({required ItemModel itemModel}) {
-    return Item(
-      id: ItemId.fromUniqueString(itemModel.id),
-      bggId: itemModel.bggId,
-      title: itemModel.title,
-      instances: const [],
-      description: itemModel.description,
-      imageUrl: itemModel.imageUrl,
-      minAge: itemModel.minAge,
-      minPlayers: itemModel.minPlayers,
-      maxPlayers: itemModel.maxPlayers,
-      playingTime: itemModel.playingTime,
-    );
   }
 }

--- a/lib/0_data/repositories/collection_repository_mock.dart
+++ b/lib/0_data/repositories/collection_repository_mock.dart
@@ -103,7 +103,7 @@ class CollectionRepositoryMock implements CollectionRepository {
   }
 
   @override
-  Future<Either<Failure, List<ItemInstance>>> getItemInstances(
+  Future<Either<Failure, List<ItemInstance>>> readItemInstances(
       List<ItemInstanceId> itemInstanceIds) {
     try {
       final itemInstances = itemInstanceIds.map((id) {
@@ -134,7 +134,7 @@ class CollectionRepositoryMock implements CollectionRepository {
       return Future.value(
           Left(ItemNotFoundFailure(itemId: itemInstance.itemId.value)));
     }
-    
+
     _itemCollection[itemInstance.itemId.value]!.instances.add(itemInstance.id);
     _itemInstances[itemInstance.id.value] = itemInstance;
     return Future.value(Right(itemInstance));

--- a/lib/0_data/repositories/collection_repository_mock.dart
+++ b/lib/0_data/repositories/collection_repository_mock.dart
@@ -35,7 +35,7 @@ class CollectionRepositoryMock implements CollectionRepository {
               id: item,
               title:
                   'Title of ${item.value} ${Random().nextInt(4) % 4 == 0 ? 'with a very long title and far more long, even too long' : ''}',
-              instances: const [],
+              instances: List<ItemInstanceId>.empty(growable: true),
               imageUrl:
                   'https://cf.geekdo-images.com/x3zxjr-Vw5iU4yDPg70Jgw__imagepagezoom/img/7a0LOL48K-7JNIOSGtcsNsIxkN0=/fit-in/1200x900/filters:no_upscale():strip_icc()/pic3490053.jpg',
               minAge: ages[Random().nextInt(ages.length)],
@@ -55,7 +55,7 @@ class CollectionRepositoryMock implements CollectionRepository {
           (index) {
             final status = ItemInstanceStatus
                 .values[Random().nextInt(ItemInstanceStatus.values.length)];
-            return ItemInstance(
+            final newInstance = ItemInstance(
               id: ItemInstanceId.fromUniqueString(
                   '${item.id.value}-instance-$index'),
               itemId: item.id,
@@ -72,6 +72,8 @@ class CollectionRepositoryMock implements CollectionRepository {
                   ? null
                   : UniqueId.fromUniqueString('borrower-$index'),
             );
+            item.instances.add(newInstance.id);
+            return newInstance;
           },
         ),
     ].fold<Map<String, ItemInstance>>(
@@ -124,6 +126,14 @@ class CollectionRepositoryMock implements CollectionRepository {
     _itemIds.add(item.id);
     _itemCollection[item.id.value] = item;
     return Future.value(Right(item));
+  }
+
+  @override
+  Future<Either<Failure, ItemInstance>> addItemInstance(
+      ItemInstance itemInstance) {
+    _itemCollection[itemInstance.itemId.value]!.instances.add(itemInstance.id);
+    _itemInstances[itemInstance.id.value] = itemInstance;
+    return Future.value(Right(itemInstance));
   }
 
   Item modelToItem({required ItemModel itemModel}) {

--- a/lib/1_domain/entities/item.dart
+++ b/lib/1_domain/entities/item.dart
@@ -2,11 +2,6 @@ import 'package:equatable/equatable.dart';
 import 'package:ludoteca/0_data/models/item_model.dart';
 import 'package:ludoteca/1_domain/entities/unique_id.dart';
 
-enum ItemStatus {
-  available,
-  unavailable,
-}
-
 class Item extends Equatable {
   final ItemId id;
   final String title;

--- a/lib/1_domain/entities/item.dart
+++ b/lib/1_domain/entities/item.dart
@@ -5,7 +5,7 @@ import 'package:ludoteca/1_domain/entities/unique_id.dart';
 class Item extends Equatable {
   final ItemId id;
   final String title;
-  final List<String> instances;
+  final List<ItemInstanceId> instances;
   final String? bggId;
   final String? imageUrl;
   final String? thumbnailUrl;
@@ -51,7 +51,9 @@ class Item extends Equatable {
     return Item(
       id: ItemId.fromUniqueString(itemModel.id),
       title: itemModel.title,
-      instances: itemModel.instances,
+      instances: itemModel.instances
+          .map((id) => ItemInstanceId.fromUniqueString(id))
+          .toList(),
       bggId: itemModel.bggId,
       imageUrl: itemModel.imageUrl,
       thumbnailUrl: itemModel.thumbnailUrl,

--- a/lib/1_domain/entities/item_instance.dart
+++ b/lib/1_domain/entities/item_instance.dart
@@ -1,0 +1,38 @@
+import 'package:equatable/equatable.dart';
+import 'package:ludoteca/1_domain/entities/unique_id.dart';
+
+enum ItemInstanceStatus {
+  available,
+  unavailable,
+}
+
+class ItemInstance extends Equatable {
+  final int instanceId;
+  final ItemId itemId;
+  final ItemInstanceStatus status;
+  final List<String>? incidences;
+  final DateTime? borrowedAt;
+  final DateTime? returnedAt;
+  final UniqueId? borrowedBy;
+
+  const ItemInstance({
+    required this.instanceId,
+    required this.itemId,
+    required this.status,
+    this.incidences = const [],
+    this.borrowedAt,
+    this.returnedAt,
+    this.borrowedBy,
+  });
+
+  @override
+  List<Object?> get props => [
+        instanceId,
+        itemId,
+        status,
+        incidences,
+        borrowedAt,
+        returnedAt,
+        borrowedBy,
+      ];
+}

--- a/lib/1_domain/entities/item_instance.dart
+++ b/lib/1_domain/entities/item_instance.dart
@@ -1,4 +1,5 @@
 import 'package:equatable/equatable.dart';
+import 'package:ludoteca/0_data/models/item_instance_model.dart';
 import 'package:ludoteca/1_domain/entities/unique_id.dart';
 
 enum ItemInstanceStatus {
@@ -24,6 +25,22 @@ class ItemInstance extends Equatable {
     this.returnedAt,
     this.borrowedBy,
   });
+
+  factory ItemInstance.fromItemInstanceModel(ItemInstanceModel itemInstanceModel) {
+    return ItemInstance(
+      instanceId: itemInstanceModel.instanceId,
+      itemId: ItemId.fromUniqueString(itemInstanceModel.itemId),
+      status: itemInstanceModel.status == 'available'
+          ? ItemInstanceStatus.available
+          : ItemInstanceStatus.unavailable,
+      incidences: itemInstanceModel.incidences,
+      borrowedAt: itemInstanceModel.borrowedAt,
+      returnedAt: itemInstanceModel.returnedAt,
+      borrowedBy: itemInstanceModel.borrowedBy != null
+          ? UniqueId.fromUniqueString(itemInstanceModel.borrowedBy!)
+          : null,
+    );
+  }
 
   @override
   List<Object?> get props => [

--- a/lib/1_domain/entities/item_instance.dart
+++ b/lib/1_domain/entities/item_instance.dart
@@ -8,7 +8,7 @@ enum ItemInstanceStatus {
 }
 
 class ItemInstance extends Equatable {
-  final int instanceId;
+  final ItemInstanceId id;
   final ItemId itemId;
   final ItemInstanceStatus status;
   final List<String>? incidences;
@@ -17,7 +17,7 @@ class ItemInstance extends Equatable {
   final UniqueId? borrowedBy;
 
   const ItemInstance({
-    required this.instanceId,
+    required this.id,
     required this.itemId,
     required this.status,
     this.incidences = const [],
@@ -26,9 +26,10 @@ class ItemInstance extends Equatable {
     this.borrowedBy,
   });
 
-  factory ItemInstance.fromItemInstanceModel(ItemInstanceModel itemInstanceModel) {
+  factory ItemInstance.fromItemInstanceModel(
+      ItemInstanceModel itemInstanceModel) {
     return ItemInstance(
-      instanceId: itemInstanceModel.instanceId,
+      id: ItemInstanceId.fromUniqueString(itemInstanceModel.id),
       itemId: ItemId.fromUniqueString(itemInstanceModel.itemId),
       status: itemInstanceModel.status == 'available'
           ? ItemInstanceStatus.available
@@ -44,7 +45,7 @@ class ItemInstance extends Equatable {
 
   @override
   List<Object?> get props => [
-        instanceId,
+        id,
         itemId,
         status,
         incidences,

--- a/lib/1_domain/entities/unique_id.dart
+++ b/lib/1_domain/entities/unique_id.dart
@@ -29,3 +29,15 @@ class ItemId extends UniqueId {
     return ItemId._(uniqueString);
   }
 }
+
+class ItemInstanceId extends UniqueId {
+  const ItemInstanceId._(super.value) : super._();
+
+  factory ItemInstanceId() {
+    return ItemInstanceId._(const Uuid().v4());
+  }
+
+  factory ItemInstanceId.fromUniqueString(String uniqueString) {
+    return ItemInstanceId._(uniqueString);
+  }
+}

--- a/lib/1_domain/failures/failures.dart
+++ b/lib/1_domain/failures/failures.dart
@@ -13,7 +13,7 @@ class ServerFailure extends Failure with EquatableMixin {
 class CacheFailure extends Failure with EquatableMixin {
   final String? stackTrace;
   CacheFailure({this.stackTrace});
-  
+
   @override
   List<Object?> get props => [stackTrace];
 }
@@ -24,4 +24,12 @@ class ItemNotFoundFailure extends Failure with EquatableMixin {
 
   @override
   List<Object?> get props => [itemId];
+}
+
+class ItemInstanceNotFoundFailure extends Failure with EquatableMixin {
+  final String itemInstanceId;
+  ItemInstanceNotFoundFailure({required this.itemInstanceId});
+
+  @override
+  List<Object?> get props => [itemInstanceId];
 }

--- a/lib/1_domain/repositories/collection_repository.dart
+++ b/lib/1_domain/repositories/collection_repository.dart
@@ -13,9 +13,10 @@ abstract class CollectionRepository {
 
   Future<Either<Failure, Item>> addItem(Item item);
 
-  Future<Either<Failure, List<ItemInstance>>> getItemInstances(
+  Future<Either<Failure, List<ItemInstance>>> readItemInstances(
     List<ItemInstanceId> itemInstanceIds,
   );
 
-  Future<Either<Failure, ItemInstance>> addItemInstance(ItemInstance itemInstance);
+  Future<Either<Failure, ItemInstance>> addItemInstance(
+      ItemInstance itemInstance);
 }

--- a/lib/1_domain/repositories/collection_repository.dart
+++ b/lib/1_domain/repositories/collection_repository.dart
@@ -1,5 +1,6 @@
 import 'package:either_dart/either.dart';
 import 'package:ludoteca/1_domain/entities/item.dart';
+import 'package:ludoteca/1_domain/entities/item_instance.dart';
 import 'package:ludoteca/1_domain/entities/unique_id.dart';
 import 'package:ludoteca/1_domain/failures/failures.dart';
 
@@ -11,4 +12,8 @@ abstract class CollectionRepository {
   Future<Either<Failure, Item>> readItem(ItemId itemId);
 
   Future<Either<Failure, Item>> addItem(Item item);
+
+  Future<Either<Failure, List<ItemInstance>>> getItemInstances(
+    List<ItemInstanceId> itemInstanceIds,
+  );
 }

--- a/lib/1_domain/repositories/collection_repository.dart
+++ b/lib/1_domain/repositories/collection_repository.dart
@@ -16,4 +16,6 @@ abstract class CollectionRepository {
   Future<Either<Failure, List<ItemInstance>>> getItemInstances(
     List<ItemInstanceId> itemInstanceIds,
   );
+
+  Future<Either<Failure, ItemInstance>> addItemInstance(ItemInstance itemInstance);
 }

--- a/lib/1_domain/use_cases/add_item_instance.dart
+++ b/lib/1_domain/use_cases/add_item_instance.dart
@@ -1,0 +1,23 @@
+import 'package:either_dart/either.dart';
+import 'package:ludoteca/1_domain/entities/item_instance.dart';
+
+import 'use_case.dart';
+import '../failures/failures.dart';
+import '../repositories/collection_repository.dart';
+
+class AddItemInstance implements UseCase<ItemInstance, AddItemInstanceParams> {
+  final CollectionRepository collectionRepository;
+  const AddItemInstance({required this.collectionRepository});
+
+  @override
+  Future<Either<Failure, ItemInstance>> call(
+      AddItemInstanceParams params) async {
+    try {
+      final itemInstance =
+          await collectionRepository.addItemInstance(params.itemInstance);
+      return itemInstance.fold((left) => Left(left), (right) => Right(right));
+    } on Exception catch (e) {
+      return Left(ServerFailure(stackTrace: e.toString()));
+    }
+  }
+}

--- a/lib/1_domain/use_cases/get_item_instances.dart
+++ b/lib/1_domain/use_cases/get_item_instances.dart
@@ -1,0 +1,23 @@
+import 'package:either_dart/either.dart';
+import 'package:ludoteca/1_domain/entities/item_instance.dart';
+import 'package:ludoteca/1_domain/failures/failures.dart';
+import 'package:ludoteca/1_domain/repositories/collection_repository.dart';
+import 'package:ludoteca/1_domain/use_cases/use_case.dart';
+
+class GetItemInstances
+    implements UseCase<List<ItemInstance>, GetItemInstancesParams> {
+  final CollectionRepository collectionRepository;
+  const GetItemInstances({required this.collectionRepository});
+
+  @override
+  Future<Either<Failure, List<ItemInstance>>> call(
+      GetItemInstancesParams params) async {
+    try {
+      final itemInstances =
+          await collectionRepository.readItemInstances(params.itemInstanceIds);
+      return itemInstances.fold((left) => Left(left), (right) => Right(right));
+    } on Exception catch (e) {
+      return Left(ServerFailure(stackTrace: e.toString()));
+    }
+  }
+}

--- a/lib/1_domain/use_cases/use_case.dart
+++ b/lib/1_domain/use_cases/use_case.dart
@@ -44,6 +44,15 @@ class AddItemInstanceParams extends Params {
   List<Object?> get props => [itemInstance];
 }
 
+class GetItemInstancesParams extends Params {
+  final List<ItemInstanceId> itemInstanceIds;
+
+  GetItemInstancesParams({required this.itemInstanceIds});
+
+  @override
+  List<Object?> get props => [itemInstanceIds];
+}
+
 class GetBggItemParams extends Params {
   final String itemId;
 

--- a/lib/1_domain/use_cases/use_case.dart
+++ b/lib/1_domain/use_cases/use_case.dart
@@ -1,5 +1,6 @@
 import 'package:either_dart/either.dart';
 import 'package:equatable/equatable.dart';
+import 'package:ludoteca/1_domain/entities/item_instance.dart';
 
 import '../entities/unique_id.dart';
 import '../failures/failures.dart';
@@ -32,6 +33,15 @@ class AddItemParams extends Params {
 
   @override
   List<Object?> get props => [item];
+}
+
+class AddItemInstanceParams extends Params {
+  final ItemInstance itemInstance;
+
+  AddItemInstanceParams({required this.itemInstance});
+
+  @override
+  List<Object?> get props => [itemInstance];
 }
 
 class GetBggItemParams extends Params {

--- a/lib/2_application/pages/collection/collection_add_item/collection_add_item_page.dart
+++ b/lib/2_application/pages/collection/collection_add_item/collection_add_item_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter_adaptive_scaffold/flutter_adaptive_scaffold.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 import 'package:ludoteca/0_data/repositories/bgg_repository.dart';
+import 'package:ludoteca/1_domain/use_cases/add_item_instance.dart';
 import 'package:ludoteca/1_domain/use_cases/get_bgg_item.dart';
 import 'package:ludoteca/i18n/strings.g.dart';
 import '../../../../1_domain/entities/item.dart';
@@ -36,6 +37,9 @@ class CollectionAddItemPageProvider extends StatelessWidget {
         return CollectionAddItemCubit(
           getBggItem: GetBggItem(bggRepository: bggRepository),
           addItem: AddCollectionItem(
+            collectionRepository: collectionRepository,
+          ),
+          addItemInstance: AddItemInstance(
             collectionRepository: collectionRepository,
           ),
         );

--- a/lib/2_application/pages/collection/collection_add_item/cubit/collection_add_item_cubit.dart
+++ b/lib/2_application/pages/collection/collection_add_item/cubit/collection_add_item_cubit.dart
@@ -1,7 +1,10 @@
 import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:ludoteca/1_domain/entities/item.dart';
+import 'package:ludoteca/1_domain/entities/item_instance.dart';
+import 'package:ludoteca/1_domain/entities/unique_id.dart';
 import 'package:ludoteca/1_domain/use_cases/add_collection_item.dart';
+import 'package:ludoteca/1_domain/use_cases/add_item_instance.dart';
 import 'package:ludoteca/1_domain/use_cases/get_bgg_item.dart';
 import 'package:ludoteca/1_domain/use_cases/use_case.dart';
 
@@ -10,8 +13,12 @@ part 'collection_add_item_cubit_state.dart';
 class CollectionAddItemCubit extends Cubit<CollectionAddItemCubitState> {
   final GetBggItem getBggItem;
   final AddCollectionItem addItem;
-  CollectionAddItemCubit({required this.getBggItem, required this.addItem})
-      : super(const CollectionAddItemEmptyState());
+  final AddItemInstance addItemInstance;
+  CollectionAddItemCubit({
+    required this.getBggItem,
+    required this.addItem,
+    required this.addItemInstance,
+  }) : super(const CollectionAddItemEmptyState());
 
   void readItemDetail(String itemId) async {
     emit(const CollectionAddItemLoadingState());
@@ -33,6 +40,14 @@ class CollectionAddItemCubit extends Cubit<CollectionAddItemCubitState> {
     if (addedItem.isLeft) {
       emit(const CollectionAddItemErrorState());
     } else {
+      final itemInstanceParams = AddItemInstanceParams(
+        itemInstance: ItemInstance(
+          id: ItemInstanceId(),
+          itemId: addedItem.right.id,
+          status: ItemInstanceStatus.available,
+        ),
+      );
+      await addItemInstance(itemInstanceParams);
       emit(CollectionAddItemAddedState(item: item));
     }
   }

--- a/lib/2_application/pages/collection/collection_item_detail/collection_item_detail_page.dart
+++ b/lib/2_application/pages/collection/collection_item_detail/collection_item_detail_page.dart
@@ -4,6 +4,7 @@ import 'package:go_router/go_router.dart';
 import 'package:ludoteca/1_domain/entities/unique_id.dart';
 import 'package:ludoteca/1_domain/repositories/collection_repository.dart';
 import 'package:ludoteca/1_domain/use_cases/get_item.dart';
+import 'package:ludoteca/1_domain/use_cases/get_item_instances.dart';
 import 'package:ludoteca/2_application/pages/collection/collection_item_detail/cubit/collection_item_detail_cubit.dart';
 import 'package:ludoteca/2_application/pages/collection/collection_item_detail/view_states/collection_item_detail_empty.dart';
 import 'package:ludoteca/2_application/pages/collection/collection_item_detail/view_states/collection_item_detail_error.dart';
@@ -23,13 +24,14 @@ class CollectionItemDetailPageProvider extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final collectionRepository =
+        RepositoryProvider.of<CollectionRepository>(context);
     return BlocProvider(
       create: (context) {
         return CollectionItemDetailCubit(
-          getItem: GetItem(
-            collectionRepository:
-                RepositoryProvider.of<CollectionRepository>(context),
-          ),
+          getItem: GetItem(collectionRepository: collectionRepository),
+          getItemInstances:
+              GetItemInstances(collectionRepository: collectionRepository),
         )..readItemDetail(selectedItem);
       },
       child: CollectionItemDetailPage(
@@ -78,7 +80,10 @@ class CollectionItemDetailPage extends StatelessWidget {
               return const CollectionItemDetailLoading();
             }
             if (state is CollectionItemDetailLoadedState) {
-              return CollectionItemDetailLoaded(item: state.item);
+              return CollectionItemDetailLoaded(
+                item: state.item,
+                itemInstances: state.itemInstances,
+              );
             }
             if (state is CollectionItemDetailEmptyState) {
               return const CollectionItemDetailEmpty();

--- a/lib/2_application/pages/collection/collection_item_detail/cubit/collection_item_detail_cubit.dart
+++ b/lib/2_application/pages/collection/collection_item_detail/cubit/collection_item_detail_cubit.dart
@@ -1,16 +1,21 @@
 import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:ludoteca/1_domain/entities/item.dart';
+import 'package:ludoteca/1_domain/entities/item_instance.dart';
 import 'package:ludoteca/1_domain/entities/unique_id.dart';
 import 'package:ludoteca/1_domain/use_cases/get_item.dart';
+import 'package:ludoteca/1_domain/use_cases/get_item_instances.dart';
 import 'package:ludoteca/1_domain/use_cases/use_case.dart';
 
 part 'collection_item_detail_cubit_state.dart';
 
 class CollectionItemDetailCubit extends Cubit<CollectionItemDetailCubitState> {
   final GetItem getItem;
-  CollectionItemDetailCubit({required this.getItem})
-      : super(const CollectionItemDetailEmptyState());
+  final GetItemInstances getItemInstances;
+  CollectionItemDetailCubit({
+    required this.getItem,
+    required this.getItemInstances,
+  }) : super(const CollectionItemDetailEmptyState());
 
   void readItemDetail(ItemId? itemId) async {
     if (itemId == null) {
@@ -25,7 +30,14 @@ class CollectionItemDetailCubit extends Cubit<CollectionItemDetailCubitState> {
     if (item.isLeft) {
       emit(const CollectionItemDetailErrorState());
     } else {
-      emit(CollectionItemDetailLoadedState(item: item.right));
+      final itemInstances = await getItemInstances(
+          GetItemInstancesParams(itemInstanceIds: item.right.instances));
+      if (itemInstances.isLeft) {
+        emit(const CollectionItemDetailErrorState());
+        return;
+      }
+
+      emit(CollectionItemDetailLoadedState(item: item.right, itemInstances: itemInstances.right));
     }
   }
 }

--- a/lib/2_application/pages/collection/collection_item_detail/cubit/collection_item_detail_cubit_state.dart
+++ b/lib/2_application/pages/collection/collection_item_detail/cubit/collection_item_detail_cubit_state.dart
@@ -20,7 +20,11 @@ final class CollectionItemDetailErrorState
 final class CollectionItemDetailLoadedState
     extends CollectionItemDetailCubitState {
   final Item item;
-  const CollectionItemDetailLoadedState({required this.item}) : super();
+  final List<ItemInstance> itemInstances;
+  const CollectionItemDetailLoadedState({
+    required this.item,
+    required this.itemInstances,
+  }) : super();
 
   @override
   List<Object> get props => [item];

--- a/lib/2_application/pages/collection/collection_item_detail/view_states/collection_item_detail_loaded.dart
+++ b/lib/2_application/pages/collection/collection_item_detail/view_states/collection_item_detail_loaded.dart
@@ -1,16 +1,22 @@
 import 'package:flutter/material.dart';
 import 'package:ludoteca/1_domain/entities/item.dart';
+import 'package:ludoteca/1_domain/entities/item_instance.dart';
 import 'package:ludoteca/2_application/pages/collection/collection_item_detail/widgets/item_detail_data/item_detail_data.dart';
 
 class CollectionItemDetailLoaded extends StatelessWidget {
   final Item item;
-  const CollectionItemDetailLoaded({super.key, required this.item});
+  final List<ItemInstance> itemInstances;
+  const CollectionItemDetailLoaded({
+    super.key,
+    required this.item,
+    required this.itemInstances,
+  });
 
   @override
   Widget build(BuildContext context) {
     final height = MediaQuery.of(context).size.height;
 
-return SingleChildScrollView(
+    return SingleChildScrollView(
       child: Container(
         color: Colors.black54,
         child: Column(
@@ -25,7 +31,7 @@ return SingleChildScrollView(
                     : const Placeholder(),
               ),
             ),
-            ItemDetailData(item: item)
+            ItemDetailData(item: item, itemInstances: itemInstances),
           ],
         ),
       ),

--- a/lib/2_application/pages/collection/collection_item_detail/widgets/item_detail_data/item_detail_data.dart
+++ b/lib/2_application/pages/collection/collection_item_detail/widgets/item_detail_data/item_detail_data.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:ludoteca/1_domain/entities/item.dart';
+import 'package:ludoteca/1_domain/entities/item_instance.dart';
 import 'package:ludoteca/2_application/pages/collection/collection_item_detail/widgets/item_detail_data/item_detail_data_header.dart';
 import 'package:ludoteca/2_application/pages/collection/widgets/item_play_properties.dart';
 
@@ -7,12 +8,30 @@ class ItemDetailData extends StatelessWidget {
   const ItemDetailData({
     super.key,
     required this.item,
+    this.itemInstances,
   });
 
   final Item item;
+  final List<ItemInstance>? itemInstances;
 
   @override
   Widget build(BuildContext context) {
+    onShowItemInstances() {
+      showDialog(
+        context: context,
+        builder: (BuildContext context) => Dialog(
+          child: Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: Column(
+              children: itemInstances!
+                  .map((instance) => Text('Item ${instance.id}'))
+                  .toList(),
+            ),
+          ),
+        ),
+      );
+    }
+
     return ConstrainedBox(
       constraints: BoxConstraints(
         minHeight: MediaQuery.of(context).size.height * 0.66,
@@ -29,7 +48,11 @@ class ItemDetailData extends StatelessWidget {
           children: [
             Padding(
               padding: const EdgeInsets.all(10.0),
-              child: ItemDetailDataHeader(title: item.title),
+              child: ItemDetailDataHeader(
+                title: item.title,
+                showItemInstancesButton: (itemInstances?.length ?? 0) > 0,
+                onShowItemInstances: onShowItemInstances,
+              ),
             ),
             Padding(
               padding: const EdgeInsets.all(10),

--- a/lib/2_application/pages/collection/collection_item_detail/widgets/item_detail_data/item_detail_data_header.dart
+++ b/lib/2_application/pages/collection/collection_item_detail/widgets/item_detail_data/item_detail_data_header.dart
@@ -4,11 +4,15 @@ import 'package:ludoteca/2_application/pages/collection/collection_item_detail/w
 class ItemDetailDataHeader extends StatelessWidget {
   final double rating;
   final String title;
+  final bool showItemInstancesButton;
+  final VoidCallback? onShowItemInstances;
 
   const ItemDetailDataHeader({
     super.key,
     required this.title,
     this.rating = -1,
+    this.showItemInstancesButton = false,
+    this.onShowItemInstances,
   });
 
   @override
@@ -16,7 +20,7 @@ class ItemDetailDataHeader extends StatelessWidget {
     return Row(
       children: [
         RatingStar(rating: rating),
-        Flexible(
+        Expanded(
           child: Container(
             padding: const EdgeInsets.all(8.0),
             child: Text(
@@ -25,6 +29,11 @@ class ItemDetailDataHeader extends StatelessWidget {
             ),
           ),
         ),
+        if (showItemInstancesButton)
+          IconButton(
+            icon: const Icon(Icons.list),
+            onPressed: onShowItemInstances,
+          ),
       ],
     );
   }

--- a/lib/2_application/pages/collection/collection_item_detail/widgets/item_detail_data/item_detail_instance_list.dart
+++ b/lib/2_application/pages/collection/collection_item_detail/widgets/item_detail_data/item_detail_instance_list.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+import 'package:ludoteca/1_domain/entities/item_instance.dart';
+
+class ItemDetailInstanceList extends StatelessWidget {
+  final List<ItemInstance> instances;
+  const ItemDetailInstanceList({super.key, required this.instances});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: instances.map(
+        (instance) {
+          return Text('Item ${instance.id}');
+        },
+      ).toList(),
+    );
+  }
+}

--- a/test/0_data/models/item_instance_model_test.dart
+++ b/test/0_data/models/item_instance_model_test.dart
@@ -1,0 +1,34 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:ludoteca/0_data/models/item_instance_model.dart';
+import 'package:ludoteca/1_domain/entities/item_instance.dart';
+import 'package:ludoteca/1_domain/entities/unique_id.dart';
+
+void main() {
+  group('ItemInstanceModel', () {
+    test('fromItemInstanceModel should return an ItemInstanceModel', () {
+      final itemInstance = ItemInstance(
+        instanceId: 1,
+        itemId: ItemId.fromUniqueString('1'),
+        status: ItemInstanceStatus.available,
+        incidences: const ['incidence'],
+        borrowedAt: DateTime.now(),
+        returnedAt: DateTime.now(),
+        borrowedBy: UniqueId.fromUniqueString('borrower'),
+      );
+
+      final itemInstanceModel = ItemInstanceModel.fromItemInstance(itemInstance);
+
+      final expectedItemInstanceModel = ItemInstanceModel(
+        instanceId: 1,
+        itemId: '1',
+        status: 'available',
+        incidences: const ['incidence'],
+        borrowedAt: itemInstance.borrowedAt,
+        returnedAt: itemInstance.returnedAt,
+        borrowedBy: 'borrower',
+      );
+
+      expect(itemInstanceModel, equals(expectedItemInstanceModel));
+    });
+  });
+}

--- a/test/0_data/models/item_instance_model_test.dart
+++ b/test/0_data/models/item_instance_model_test.dart
@@ -7,7 +7,7 @@ void main() {
   group('ItemInstanceModel', () {
     test('fromItemInstanceModel should return an ItemInstanceModel', () {
       final itemInstance = ItemInstance(
-        instanceId: 1,
+        id: ItemInstanceId.fromUniqueString('1'),
         itemId: ItemId.fromUniqueString('1'),
         status: ItemInstanceStatus.available,
         incidences: const ['incidence'],
@@ -16,10 +16,11 @@ void main() {
         borrowedBy: UniqueId.fromUniqueString('borrower'),
       );
 
-      final itemInstanceModel = ItemInstanceModel.fromItemInstance(itemInstance);
+      final itemInstanceModel =
+          ItemInstanceModel.fromItemInstance(itemInstance);
 
       final expectedItemInstanceModel = ItemInstanceModel(
-        instanceId: 1,
+        id: '1',
         itemId: '1',
         status: 'available',
         incidences: const ['incidence'],

--- a/test/0_data/models/item_model_test.dart
+++ b/test/0_data/models/item_model_test.dart
@@ -62,7 +62,10 @@ void main() {
         publishYear: 1986,
         complexity: 3.5,
         rating: 4.2,
-        instances: const ['instance1', 'instance2'],
+        instances: [
+          ItemInstanceId.fromUniqueString('instance1'),
+          ItemInstanceId.fromUniqueString('instance2')
+        ],
       );
 
       // Convert Item to ItemModel

--- a/test/0_data/repositories/collection_repository_local_test.dart
+++ b/test/0_data/repositories/collection_repository_local_test.dart
@@ -355,7 +355,7 @@ void main() {
               itemInstanceIds.map((itemId) => itemId.value).toList()))
           .thenAnswer((_) async => itemInstanceModels);
 
-      final result = await repository.getItemInstances(itemInstanceIds);
+      final result = await repository.readItemInstances(itemInstanceIds);
 
       expect(result.isRight, true);
       expect(
@@ -377,7 +377,7 @@ void main() {
               itemInstanceIds.map((itemId) => itemId.value).toList()))
           .thenThrow(ItemInstanceNotFoundException('id2'));
 
-      final result = await repository.getItemInstances(itemInstanceIds);
+      final result = await repository.readItemInstances(itemInstanceIds);
 
       expect(result.isLeft, true);
       expect(
@@ -399,7 +399,7 @@ void main() {
               itemInstanceIds.map((itemId) => itemId.value).toList()))
           .thenThrow(CacheException());
 
-      final result = await repository.getItemInstances(itemInstanceIds);
+      final result = await repository.readItemInstances(itemInstanceIds);
 
       expect(result.isLeft, true);
       expect(
@@ -421,7 +421,7 @@ void main() {
               itemInstanceIds.map((itemId) => itemId.value).toList()))
           .thenThrow(Exception());
 
-      final result = await repository.getItemInstances(itemInstanceIds);
+      final result = await repository.readItemInstances(itemInstanceIds);
 
       expect(result, equals(Left(ServerFailure(stackTrace: 'Exception'))));
     });

--- a/test/0_data/repositories/collection_repository_local_test.dart
+++ b/test/0_data/repositories/collection_repository_local_test.dart
@@ -101,9 +101,12 @@ void main() {
         equals(itemModelList
             .map(
               (itemModel) => Item(
-                  id: ItemId.fromUniqueString(itemModel.id),
-                  title: itemModel.title,
-                  instances: itemModel.instances),
+                id: ItemId.fromUniqueString(itemModel.id),
+                title: itemModel.title,
+                instances: itemModel.instances
+                    .map((id) => ItemInstanceId.fromUniqueString(id))
+                    .toList(),
+              ),
             )
             .toList()),
       );
@@ -180,7 +183,9 @@ void main() {
           Item(
             id: ItemId.fromUniqueString(itemModel.id),
             title: itemModel.title,
-            instances: itemModel.instances,
+            instances: itemModel.instances
+                .map((id) => ItemInstanceId.fromUniqueString(id))
+                .toList(),
           ),
         ),
       );
@@ -335,7 +340,10 @@ void main() {
             Item(
               id: ItemId.fromUniqueString(itemModelList[index].id),
               title: itemModelList[index].title,
-              instances: itemModelList[index].instances,
+              instances: itemModelList[index]
+                  .instances
+                  .map((id) => ItemInstanceId.fromUniqueString(id))
+                  .toList(),
               bggId: itemModelList[index].bggId,
               imageUrl: itemModelList[index].imageUrl,
               thumbnailUrl: itemModelList[index].thumbnailUrl,

--- a/test/0_data/repositories/collection_repository_local_test.dart
+++ b/test/0_data/repositories/collection_repository_local_test.dart
@@ -386,7 +386,8 @@ void main() {
       );
     });
 
-    test('should return a CacheFailure when localDataSource throws a CacheException',
+    test(
+        'should return a CacheFailure when localDataSource throws a CacheException',
         () async {
       final itemInstanceIds = [
         ItemInstanceId.fromUniqueString('id1'),
@@ -421,6 +422,99 @@ void main() {
           .thenThrow(Exception());
 
       final result = await repository.getItemInstances(itemInstanceIds);
+
+      expect(result, equals(Left(ServerFailure(stackTrace: 'Exception'))));
+    });
+  });
+
+  group('addItemInstance', () {
+    test('should return the ItemInstance when sucesfully added an it',
+        () async {
+      final itemInstanceToAdd = ItemInstance(
+        id: ItemInstanceId.fromUniqueString('instance1'),
+        itemId: ItemId.fromUniqueString('id1'),
+        status: ItemInstanceStatus.available,
+        borrowedBy: null,
+        returnedAt: DateTime.now(),
+      );
+
+      when(() => mockLocalDataSource.addItemInstance(
+              itemInstanceModel:
+                  ItemInstanceModel.fromItemInstance(itemInstanceToAdd)))
+          .thenAnswer((_) async => true);
+
+      final result = await repository.addItemInstance(itemInstanceToAdd);
+
+      expect(result, equals(Right(itemInstanceToAdd)));
+      verify(
+        () => mockLocalDataSource.addItemInstance(
+          itemInstanceModel:
+              ItemInstanceModel.fromItemInstance(itemInstanceToAdd),
+        ),
+      ).called(1);
+    });
+
+    test('should return a ItemNotFoundFailure when the item is not found',
+        () async {
+      final itemInstanceToAdd = ItemInstance(
+        id: ItemInstanceId.fromUniqueString('instance1'),
+        itemId: ItemId.fromUniqueString('id1'),
+        status: ItemInstanceStatus.available,
+        borrowedBy: null,
+        returnedAt: DateTime.now(),
+      );
+
+      when(() => mockLocalDataSource.addItemInstance(
+              itemInstanceModel:
+                  ItemInstanceModel.fromItemInstance(itemInstanceToAdd)))
+          .thenAnswer((_) => Future.value(false));
+
+      final result = await repository.addItemInstance(itemInstanceToAdd);
+
+      expect(result, equals(Left(ItemNotFoundFailure(itemId: 'id1'))));
+    });
+
+    test(
+        'should return a CacheFailure when localDataSource throws a CacheException',
+        () async {
+      final itemInstanceToAdd = ItemInstance(
+        id: ItemInstanceId.fromUniqueString('instance1'),
+        itemId: ItemId.fromUniqueString('id1'),
+        status: ItemInstanceStatus.available,
+        borrowedBy: null,
+        returnedAt: DateTime.now(),
+      );
+
+      when(() => mockLocalDataSource.addItemInstance(
+              itemInstanceModel:
+                  ItemInstanceModel.fromItemInstance(itemInstanceToAdd)))
+          .thenThrow(CacheException());
+
+      final result = await repository.addItemInstance(itemInstanceToAdd);
+
+      expect(result.isLeft, true);
+      expect(
+        result.left,
+        isA<CacheFailure>(),
+      );
+    });
+
+    test(
+        'should return a ServerFailure when localDataSource throws an Exception',
+        () async {
+      final itemInstanceToAdd = ItemInstance(
+        id: ItemInstanceId.fromUniqueString('instance1'),
+        itemId: ItemId.fromUniqueString('id1'),
+        status: ItemInstanceStatus.available,
+        borrowedBy: null,
+        returnedAt: DateTime.now(),
+      );
+      when(() => mockLocalDataSource.addItemInstance(
+              itemInstanceModel:
+                  ItemInstanceModel.fromItemInstance(itemInstanceToAdd)))
+          .thenThrow(Exception());
+
+      final result = await repository.addItemInstance(itemInstanceToAdd);
 
       expect(result, equals(Left(ServerFailure(stackTrace: 'Exception'))));
     });

--- a/test/1_domain/entities/item_instance_test.dart
+++ b/test/1_domain/entities/item_instance_test.dart
@@ -1,0 +1,38 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:ludoteca/0_data/models/item_instance_model.dart';
+import 'package:ludoteca/1_domain/entities/item_instance.dart';
+import 'package:ludoteca/1_domain/entities/unique_id.dart';
+
+void main() {
+  group('ItemInstance', () {
+    test('should create an ItemInstance from an ItemInstanceModel', () {
+      final itemInstanceModel = ItemInstanceModel(
+        instanceId: 1,
+        itemId: '1',
+        status: 'available',
+        incidences: const ['incidence'],
+        borrowedAt: DateTime.now(),
+        returnedAt: DateTime.now(),
+        borrowedBy: 'borrower',
+      );
+
+      final itemInstance =
+          ItemInstance.fromItemInstanceModel(itemInstanceModel);
+
+      final expectedItemInstance = ItemInstance(
+        instanceId: itemInstanceModel.instanceId,
+        itemId: ItemId.fromUniqueString(itemInstanceModel.itemId),
+        status: ItemInstanceStatus.available,
+        incidences: itemInstanceModel.incidences,
+        borrowedAt: itemInstanceModel.borrowedAt,
+        returnedAt: itemInstanceModel.returnedAt,
+        borrowedBy: itemInstanceModel.borrowedBy != null
+            ? UniqueId.fromUniqueString(itemInstanceModel.borrowedBy!)
+            : null,
+      );
+
+      // Compare the two objects
+      expect(itemInstance, equals(expectedItemInstance));
+    });
+  });
+}

--- a/test/1_domain/entities/item_instance_test.dart
+++ b/test/1_domain/entities/item_instance_test.dart
@@ -7,7 +7,7 @@ void main() {
   group('ItemInstance', () {
     test('should create an ItemInstance from an ItemInstanceModel', () {
       final itemInstanceModel = ItemInstanceModel(
-        instanceId: 1,
+        id: '0',
         itemId: '1',
         status: 'available',
         incidences: const ['incidence'],
@@ -20,7 +20,7 @@ void main() {
           ItemInstance.fromItemInstanceModel(itemInstanceModel);
 
       final expectedItemInstance = ItemInstance(
-        instanceId: itemInstanceModel.instanceId,
+        id: ItemInstanceId.fromUniqueString('0'),
         itemId: ItemId.fromUniqueString(itemInstanceModel.itemId),
         status: ItemInstanceStatus.available,
         incidences: itemInstanceModel.incidences,

--- a/test/1_domain/entities/item_test.dart
+++ b/test/1_domain/entities/item_test.dart
@@ -39,7 +39,9 @@ void main() {
           Item(
             id: ItemId.fromUniqueString(itemModel.id),
             title: itemModel.title,
-            instances: itemModel.instances,
+            instances: itemModel.instances
+                .map((id) => ItemInstanceId.fromUniqueString(id))
+                .toList(),
             bggId: itemModel.bggId,
             imageUrl: itemModel.imageUrl,
             thumbnailUrl: itemModel.thumbnailUrl,

--- a/test/1_domain/use_cases/add_collection_item_test.dart
+++ b/test/1_domain/use_cases/add_collection_item_test.dart
@@ -8,7 +8,7 @@ import 'package:ludoteca/1_domain/use_cases/add_collection_item.dart';
 import 'package:ludoteca/1_domain/use_cases/use_case.dart';
 import 'package:mocktail/mocktail.dart';
 
-class CollectionRepositoryMock extends Mock implements CollectionRepository {}
+class MockCollectionRepository extends Mock implements CollectionRepository {}
 
 void main() {
   final fakeItem = Item(
@@ -32,7 +32,7 @@ void main() {
   group('AddCollectionItem use case', () {
     group('should return Right', () {
       test('with an Item', () async {
-        final mockCollectionRepository = CollectionRepositoryMock();
+        final mockCollectionRepository = MockCollectionRepository();
         when(() => mockCollectionRepository.addItem(fakeItem)).thenAnswer(
           (_) async => Right(fakeItem),
         );
@@ -53,7 +53,7 @@ void main() {
 
     group('should return left', () {
       test('with a ServerFailure if threw an exception', () async {
-        final mockCollectionRepository = CollectionRepositoryMock();
+        final mockCollectionRepository = MockCollectionRepository();
         when(() => mockCollectionRepository.addItem(fakeItem)).thenThrow(
           Exception('something went wrong'),
         );

--- a/test/1_domain/use_cases/add_item_instance_test.dart
+++ b/test/1_domain/use_cases/add_item_instance_test.dart
@@ -1,0 +1,69 @@
+import 'package:either_dart/either.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:ludoteca/1_domain/entities/item_instance.dart';
+import 'package:ludoteca/1_domain/entities/unique_id.dart';
+import 'package:ludoteca/1_domain/failures/failures.dart';
+import 'package:ludoteca/1_domain/repositories/collection_repository.dart';
+import 'package:ludoteca/1_domain/use_cases/add_item_instance.dart';
+import 'package:ludoteca/1_domain/use_cases/use_case.dart';
+import 'package:mocktail/mocktail.dart';
+
+class MockCollectionRepository extends Mock implements CollectionRepository {}
+
+void main() {
+  final fakeItemInstance = ItemInstance(
+    id: ItemInstanceId.fromUniqueString('0'),
+    itemId: ItemId.fromUniqueString('1'),
+    status: ItemInstanceStatus.available,
+    incidences: const ['incidence'],
+    returnedAt: DateTime.now(),
+  );
+
+  group('AddItemInstance use case', () {
+    group('should return Right', () {
+      test('with an ItemInstance', () async {
+        final mockCollectionRepository = MockCollectionRepository();
+        when(() => mockCollectionRepository.addItemInstance(fakeItemInstance))
+            .thenAnswer((_) async => Right(fakeItemInstance));
+
+        final addItemInstanceUseCase = AddItemInstance(
+          collectionRepository: mockCollectionRepository,
+        );
+
+        final result = await addItemInstanceUseCase(
+          AddItemInstanceParams(itemInstance: fakeItemInstance),
+        );
+
+        expect(result, Right<Failure, ItemInstance>(fakeItemInstance));
+
+        verify(() => mockCollectionRepository.addItemInstance(fakeItemInstance))
+            .called(1);
+      });
+    });
+
+    group('should return left', () {
+      test('with a ServerFailure if threw an exception', () async {
+        final mockCollectionRepository = MockCollectionRepository();
+        when(() => mockCollectionRepository.addItemInstance(fakeItemInstance))
+            .thenThrow(Exception('something went wrong'));
+
+        final addItemInstanceUseCase = AddItemInstance(
+          collectionRepository: mockCollectionRepository,
+        );
+
+        final result = await addItemInstanceUseCase(
+          AddItemInstanceParams(itemInstance: fakeItemInstance),
+        );
+
+        expect(result.isLeft, true);
+        expect(
+          result.left,
+          ServerFailure(stackTrace: 'Exception: something went wrong'),
+        );
+
+        verify(() => mockCollectionRepository.addItemInstance(fakeItemInstance))
+            .called(1);
+      });
+    });
+  });
+}

--- a/test/1_domain/use_cases/get_item_instances_test.dart
+++ b/test/1_domain/use_cases/get_item_instances_test.dart
@@ -1,0 +1,99 @@
+import 'package:either_dart/either.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:ludoteca/1_domain/entities/item_instance.dart';
+import 'package:ludoteca/1_domain/entities/unique_id.dart';
+import 'package:ludoteca/1_domain/failures/failures.dart';
+import 'package:ludoteca/1_domain/repositories/collection_repository.dart';
+import 'package:ludoteca/1_domain/use_cases/get_item_instances.dart';
+import 'package:ludoteca/1_domain/use_cases/use_case.dart';
+import 'package:mocktail/mocktail.dart';
+
+class MockCollectionRepository extends Mock implements CollectionRepository {}
+
+void main() {
+  final fakeItemInstances = [
+    ItemInstance(
+      id: ItemInstanceId.fromUniqueString('i0'),
+      itemId: ItemId.fromUniqueString('0'),
+      status: ItemInstanceStatus.available,
+    ),
+    ItemInstance(
+      id: ItemInstanceId.fromUniqueString('i1'),
+      itemId: ItemId.fromUniqueString('0'),
+      status: ItemInstanceStatus.unavailable,
+      borrowedAt: DateTime.now(),
+      borrowedBy: UniqueId.fromUniqueString('u0'),
+    ),
+  ];
+
+  group('GetItemInstances use case', () {
+    group('should return Right', () {
+      test('with ItemDetail list', () async {
+        final mockCollectionRepository = MockCollectionRepository();
+        when(
+          () => mockCollectionRepository.readItemInstances([
+            ItemInstanceId.fromUniqueString('i0'),
+            ItemInstanceId.fromUniqueString('i1')
+          ]),
+        ).thenAnswer(
+          (_) async => Right(fakeItemInstances),
+        );
+
+        final getItemDetailUseCase = GetItemInstances(
+          collectionRepository: mockCollectionRepository,
+        );
+
+        final result = await getItemDetailUseCase(
+          GetItemInstancesParams(
+            itemInstanceIds: [
+              ItemInstanceId.fromUniqueString('i0'),
+              ItemInstanceId.fromUniqueString('i1')
+            ],
+          ),
+        );
+
+        expect(result, Right<Failure, List<ItemInstance>>(fakeItemInstances));
+
+        verify(
+          () => mockCollectionRepository.readItemInstances([
+            ItemInstanceId.fromUniqueString('i0'),
+            ItemInstanceId.fromUniqueString('i1')
+          ]),
+        ).called(1);
+      });
+    });
+
+    group('should return left', () {
+      test('with a ServerFailure if threw an exception', () async {
+        final mockCollectionRepository = MockCollectionRepository();
+        when(() => mockCollectionRepository
+                .readItemInstances([ItemInstanceId.fromUniqueString('0')]))
+            .thenThrow(
+          Exception('something went wrong'),
+        );
+
+        final getItemDetailUseCase = GetItemInstances(
+          collectionRepository: mockCollectionRepository,
+        );
+
+        final result = await getItemDetailUseCase(
+          GetItemInstancesParams(
+            itemInstanceIds: [ItemInstanceId.fromUniqueString('0')],
+          ),
+        );
+
+        expect(result.isLeft, true);
+        expect(
+          result.left,
+          ServerFailure(stackTrace: 'Exception: something went wrong'),
+        );
+
+        verify(
+          () => mockCollectionRepository.readItemInstances(
+            [ItemInstanceId.fromUniqueString('0')],
+          ),
+        ).called(1);
+      });
+    });
+  });
+}

--- a/test/2_application/pages/collection/collection_item_detail/collection_item_detail_page_test.dart
+++ b/test/2_application/pages/collection/collection_item_detail/collection_item_detail_page_test.dart
@@ -111,7 +111,8 @@ void main() {
             Stream.fromIterable([
               const CollectionItemDetailEmptyState(),
               const CollectionItemDetailLoadingState(),
-              CollectionItemDetailLoadedState(item: Item.empty()),
+              CollectionItemDetailLoadedState(
+                  item: Item.empty(), itemInstances: const []),
             ]),
             initialState: const CollectionItemDetailEmptyState(),
           );

--- a/test/2_application/pages/collection/collection_item_detail/view_states/collection_item_detail_loaded_test.dart
+++ b/test/2_application/pages/collection/collection_item_detail/view_states/collection_item_detail_loaded_test.dart
@@ -9,7 +9,10 @@ import 'package:mocktail_image_network/mocktail_image_network.dart';
 void main() {
   Widget widgetUnderTest(Item item) {
     return MaterialApp(
-      home: CollectionItemDetailLoaded(item: item),
+      home: CollectionItemDetailLoaded(
+        item: item,
+        itemInstances: const [],
+      ),
     );
   }
 

--- a/test/2_application/pages/collection/collection_item_detail/widgets/item_detail_data/item_detail_data_header_test.dart
+++ b/test/2_application/pages/collection/collection_item_detail/widgets/item_detail_data/item_detail_data_header_test.dart
@@ -4,11 +4,17 @@ import 'package:ludoteca/2_application/pages/collection/collection_item_detail/w
 import 'package:ludoteca/2_application/pages/collection/collection_item_detail/widgets/rating_star.dart';
 
 void main() {
-  Widget widgetUnderTest({required String title, double rating = -1}) {
+  Widget widgetUnderTest(
+      {required String title,
+      double rating = -1,
+      bool showItemInstancesButton = false,
+      onShowItemInstances}) {
     return MaterialApp(
       home: ItemDetailDataHeader(
         title: title,
         rating: rating,
+        showItemInstancesButton: showItemInstancesButton,
+        onShowItemInstances: onShowItemInstances,
       ),
     );
   }
@@ -28,6 +34,35 @@ void main() {
       );
 
       expect(find.text('a title'), findsOneWidget);
+    });
+
+    testWidgets(
+        'should render a item detail button when showItemInstancesButton is true',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        widgetUnderTest(title: 'a title', showItemInstancesButton: true),
+      );
+
+      expect(find.byIcon(Icons.list), findsOneWidget);
+    });
+
+    testWidgets(
+        'should call onShowItemInstances when item detail button is pressed',
+        (WidgetTester tester) async {
+      var pressed = false;
+      await tester.pumpWidget(
+        widgetUnderTest(
+          title: 'a title',
+          showItemInstancesButton: true,
+          onShowItemInstances: () {
+            pressed = true;
+          },
+        ),
+      );
+
+      await tester.tap(find.byIcon(Icons.list));
+
+      expect(pressed, true);
     });
   });
 }

--- a/test/2_application/pages/collection/collection_list/view_states/collection_list_loaded_test.dart
+++ b/test/2_application/pages/collection/collection_list/view_states/collection_list_loaded_test.dart
@@ -46,7 +46,7 @@ void main() {
                 mockCollectionListCubit ??
                 CollectionListCubit(
                   getCollectionItems: GetCollectionItems(
-                    collectionRepository: CollectionRepositoryMock(),
+                    collectionRepository: MockCollectionRepository(),
                   ),
                 ),
           ),


### PR DESCRIPTION
This LONG Pr adds a basic ItemInstances implementation, adding the repo Instances, use cases for adding and querying instances and a fake widget (to improve) to show the existing ones.
Right now, only when new Item is added I add an instance, I should add controls to add new instances or even remove them.